### PR TITLE
[DOT-4417] Added a config to ignore HTTPs/SSL error for smartui-cli

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -24,7 +24,8 @@ export default {
         },
         waitForTimeout: 1000,
         enableJavaScript: false,
-        allowedHostnames: [], 
+        allowedHostnames: [],
+        smartIgnore: false
     },
     DEFAULT_WEB_STATIC_CONFIG: [
         {

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -25,7 +25,8 @@ export default {
         waitForTimeout: 1000,
         enableJavaScript: false,
         allowedHostnames: [],
-        smartIgnore: false
+        smartIgnore: false,
+        ignoreHTTPSErrors : false
     },
     DEFAULT_WEB_STATIC_CONFIG: [
         {

--- a/src/lib/ctx.ts
+++ b/src/lib/ctx.ts
@@ -96,7 +96,7 @@ export default (options: Record<string, string>): Context => {
             basicAuthorization: basicAuthObj,
             smartIgnore: config.smartIgnore ?? false,
             delayedUpload: config.delayedUpload ?? false,
-            useGlobalCache: config.useGlobalCache ?? false
+            useGlobalCache: config.useGlobalCache ?? false,
         },
         uploadFilePath: '',
         webStaticConfig: [],

--- a/src/lib/ctx.ts
+++ b/src/lib/ctx.ts
@@ -94,7 +94,8 @@ export default (options: Record<string, string>): Context => {
             allowedHostnames: config.allowedHostnames || [],
             basicAuthorization: basicAuthObj,
             smartIgnore: config.smartIgnore ?? false,
-            delayedUpload: config.delayedUpload ?? false
+            delayedUpload: config.delayedUpload ?? false,
+            ignoreHTTPSErrors: config.ignoreHTTPSErrors ?? false
         },
         uploadFilePath: '',
         webStaticConfig: [],

--- a/src/lib/ctx.ts
+++ b/src/lib/ctx.ts
@@ -96,11 +96,7 @@ export default (options: Record<string, string>): Context => {
             basicAuthorization: basicAuthObj,
             smartIgnore: config.smartIgnore ?? false,
             delayedUpload: config.delayedUpload ?? false,
-<<<<<<< HEAD
-            ignoreHTTPSErrors: config.ignoreHTTPSErrors ?? false
-=======
             useGlobalCache: config.useGlobalCache ?? false
->>>>>>> upstream/stage
         },
         uploadFilePath: '',
         webStaticConfig: [],

--- a/src/lib/processSnapshot.ts
+++ b/src/lib/processSnapshot.ts
@@ -22,6 +22,7 @@ export default async function processSnapshot(snapshot: Snapshot, ctx: Context):
     let contextOptions: Record<string, any> = {
         javaScriptEnabled: ctx.config.cliEnableJavaScript,
         userAgent: constants.CHROME_USER_AGENT,
+        ignoreHTTPSErrors : ctx.config.ignoreHTTPSErrors
     }
     if (!ctx.browser?.isConnected()) {
         if (ctx.env.HTTP_PROXY || ctx.env.HTTPS_PROXY) launchOptions.proxy = { server: ctx.env.HTTP_PROXY || ctx.env.HTTPS_PROXY };

--- a/src/lib/schemaValidation.ts
+++ b/src/lib/schemaValidation.ts
@@ -117,6 +117,10 @@ const ConfigSchema = {
             type: "boolean",
             errorMessage: "Invalid config; smartIgnore must be true/false"
         },
+        ignoreHTTPSErrors: {
+            type : "boolean",
+            errorMessage: "Invalid config; ignoreHttpsError must be true/false"
+        },
         scrollTime: {
             type: "number",
             minimum: 1,

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,7 @@ export interface Context {
         smartIgnore: boolean;
         delayedUpload: boolean;
         figma?: FigmaWebConfig;
+        ignoreHTTPSErrors : boolean;
     };
     uploadFilePath: string;
     webStaticConfig: WebStaticConfig;


### PR DESCRIPTION
Added a flag ignoreHttpsErrors in config, which is by default set as false, but user can overwrite the config and set it to yes if he/she/they want to skip SSL (self-signed, expired etc) certifications checks while performing their tests on SmartUi CLI.