### PR TITLE
Release 4.1.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lambdatest/smartui-cli",
-  "version": "4.1.14",
+  "version": "4.1.15",
   "description": "A command line interface (CLI) to run SmartUI tests on LambdaTest",
   "files": [
     "dist/**/*"

--- a/src/commander/capture.ts
+++ b/src/commander/capture.ts
@@ -87,6 +87,7 @@ command
             await tasks.run(ctx);
         } catch (error) {
             console.log('\nRefer docs: https://www.lambdatest.com/support/docs/smart-visual-regression-testing/');
+            process.exitCode = 1;
         }
 
     })

--- a/src/commander/exec.ts
+++ b/src/commander/exec.ts
@@ -67,6 +67,7 @@ command
             await tasks.run(ctx);
         } catch (error) {
             ctx.log.info('\nRefer docs: https://www.lambdatest.com/support/docs/smart-visual-regression-testing/');
+            process.exitCode = 1;
             throw new Error();
         }
     })

--- a/src/commander/mergeBuild.ts
+++ b/src/commander/mergeBuild.ts
@@ -55,6 +55,7 @@ command
             await tasks.run(ctx);
         } catch (error) {
             console.error('Error during merge operation:', error);
+            process.exitCode = 1;
         }
     });
 

--- a/src/commander/upload.ts
+++ b/src/commander/upload.ts
@@ -73,6 +73,7 @@ command
             await tasks.run(ctx);
         } catch (error) {
             console.log('\nRefer docs: https://www.lambdatest.com/support/docs/smart-visual-regression-testing/');
+            process.exitCode = 1;
         }
 
     });

--- a/src/commander/uploadFigma.ts
+++ b/src/commander/uploadFigma.ts
@@ -103,6 +103,7 @@ uploadWebFigmaCommand
             verifyFigmaWebConfig(ctx);
         } catch (error: any) {
             ctx.log.error(chalk.red(`Invalid figma-web config; ${error.message}`));
+            process.exitCode = 1;
             return;
         }
 
@@ -169,6 +170,7 @@ uploadWebFigmaCommand
             verifyFigmaWebConfig(ctx);
         } catch (error: any) {
             ctx.log.error(chalk.red(`Invalid figma-app config; ${error.message}`));
+            process.exitCode = 1;
             return;
         }
 

--- a/src/tasks/createBuild.ts
+++ b/src/tasks/createBuild.ts
@@ -19,7 +19,7 @@ export default (ctx: Context): ListrTask<Context, ListrRendererFactory, ListrRen
                         baseline: resp.data.baseline,
                         useKafkaFlow: resp.data.useKafkaFlow || false,
                     }
-                    process.env.SMARTUI_BUILD = resp.data.buildId;
+                    process.env.SMARTUI_BUILD_ID = resp.data.buildId;
                     process.env.SMARTUI_BUILD_NAME = resp.data.buildName;
                 } else if (resp && resp.error) {
                     if (resp.error.message) {

--- a/src/tasks/createBuild.ts
+++ b/src/tasks/createBuild.ts
@@ -19,6 +19,8 @@ export default (ctx: Context): ListrTask<Context, ListrRendererFactory, ListrRen
                         baseline: resp.data.baseline,
                         useKafkaFlow: resp.data.useKafkaFlow || false,
                     }
+                    process.env.SMARTUI_BUILD = resp.data.buildId;
+                    process.env.SMARTUI_BUILD_NAME = resp.data.buildName;
                 } else if (resp && resp.error) {
                     if (resp.error.message) {
                         ctx.log.error(`Error while creation of build: ${resp.error.message}`)

--- a/src/tasks/createBuildExec.ts
+++ b/src/tasks/createBuildExec.ts
@@ -21,6 +21,8 @@ export default (ctx: Context): ListrTask<Context, ListrRendererFactory, ListrRen
                             baseline: resp.data.baseline,
                             useKafkaFlow: resp.data.useKafkaFlow || false,
                         }
+                        process.env.SMARTUI_BUILD = resp.data.buildId;
+                        process.env.SMARTUI_BUILD_NAME = resp.data.buildName;
                     } else if (resp && resp.error) {
                         if (resp.error.message) {
                             ctx.log.error(`Error while creation of build: ${resp.error.message}`)

--- a/src/tasks/createBuildExec.ts
+++ b/src/tasks/createBuildExec.ts
@@ -21,7 +21,7 @@ export default (ctx: Context): ListrTask<Context, ListrRendererFactory, ListrRen
                             baseline: resp.data.baseline,
                             useKafkaFlow: resp.data.useKafkaFlow || false,
                         }
-                        process.env.SMARTUI_BUILD = resp.data.buildId;
+                        process.env.SMARTUI_BUILD_ID = resp.data.buildId;
                         process.env.SMARTUI_BUILD_NAME = resp.data.buildName;
                     } else if (resp && resp.error) {
                         if (resp.error.message) {

--- a/src/tasks/exec.ts
+++ b/src/tasks/exec.ts
@@ -38,10 +38,14 @@ export default (ctx: Context): ListrTask<Context, ListrRendererFactory, ListrRen
                 childProcess.on('close', async (code, signal) => {
                     if (code !== null) {
                         task.title = `Execution of '${ctx.args.execCommand?.join(' ')}' completed; exited with code ${code}`;
+                        if (code !== 0) {
+                            reject();
+                            process.exitCode = code
+                        }
                     } else if (signal !== null) {
                         throw new Error(`Child process killed with signal ${signal}`);
                     }
-
+                    
                     resolve();
                 });
             });

--- a/src/tasks/processSnapshot.ts
+++ b/src/tasks/processSnapshot.ts
@@ -28,7 +28,10 @@ export default (ctx: Context): ListrTask<Context, ListrRendererFactory, ListrRen
 
                 let output = '';
                 for (let snapshot of ctx.snapshotQueue?.getProcessedSnapshots()) {
-                    if (snapshot.error) output += `${chalk.red('\u{2717}')} ${chalk.gray(`${snapshot.name}\n[error] ${snapshot.error}`)}\n`;
+                    if (snapshot.error){ 
+                        output += `${chalk.red('\u{2717}')} ${chalk.gray(`${snapshot.name}\n[error] ${snapshot.error}`)}\n`;
+                        process.exitCode = 1;
+                    }
                     else output += `${chalk.green('\u{2713}')} ${chalk.gray(snapshot.name)}\n${snapshot.warnings.length ?  chalk.gray(`[warning] ${snapshot.warnings.join('\n[warning] ')}\n`) : ''}`;
                 }
                 task.output = output;
@@ -36,6 +39,7 @@ export default (ctx: Context): ListrTask<Context, ListrRendererFactory, ListrRen
             } catch (error: any) {
                 ctx.log.debug(error);
                 task.output = chalk.gray(error.message);
+                process.exitCode = 1;
                 throw new Error('Processing of snapshots failed');
             }
         },


### PR DESCRIPTION
This pull request introduces several updates to improve error handling and environment variable management in the `@lambdatest/smartui-cli` project. The most significant changes include setting process exit codes on errors across multiple commands and tasks, introducing environment variables for build information, and refining error handling in snapshot processing.

### Error handling improvements:
* Added `process.exitCode = 1` in various commands (`capture`, `exec`, `mergeBuild`, `upload`, `uploadFigma`) to ensure proper exit codes are set on errors. This change standardizes error handling across the CLI. [[1]](diffhunk://#diff-c8602f4b58a8acf8433b596d5869752df26d38bd004341664ba399908a8a880eR90) [[2]](diffhunk://#diff-d08300c5e6ac5b52e42780a1cb6bbd7934bedaa07b8e9d26b36b3a8d93c1b563R70) [[3]](diffhunk://#diff-c42a49d26c2d298f3aa296eb72f0c2f7ecec194a3b6fe668a1cec09ecf2beafbR58) [[4]](diffhunk://#diff-d321e5fc5e27cba078c0d3c0e3d658699fd5bf7b24b31df73f7356bbcb928ba6R76) [[5]](diffhunk://#diff-86a9c6b25f15b4ec4763626da3fcca0a432ee1c6606ec771ffdc865b6a1b03f1R106) [[6]](diffhunk://#diff-86a9c6b25f15b4ec4763626da3fcca0a432ee1c6606ec771ffdc865b6a1b03f1R173)
* Updated the `exec` task to set `process.exitCode` and reject the promise if a child process exits with a non-zero code.
* Enhanced error handling in `processSnapshot` by setting `process.exitCode = 1` when snapshot errors are encountered or when the snapshot processing fails entirely.

### Environment variable management:
* Added `process.env.SMARTUI_BUILD_ID` and `process.env.SMARTUI_BUILD_NAME` in `createBuild` and `createBuildExec` tasks to expose build information as environment variables for downstream processes. [[1]](diffhunk://#diff-e768443d835f20284f4bcfcefbc001aeb0c5f772e9f6e42cb9fb91c39b67756fR22-R23) [[2]](diffhunk://#diff-b4898f56a740aa9652230f3119ad8a067669f84fcd378fe0421a94dd64af49e5R24-R25)

### Version update:
* Bumped the package version in `package.json` from `4.1.14` to `4.1.15`.