### PR TITLE
Add support for allowDuplicateSnapshotNames configuration 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 dist
+.idea
+pnpm-lock.yaml

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lambdatest/smartui-cli",
-  "version": "4.1.17",
+  "version": "4.1.18-beta.0",
   "description": "A command line interface (CLI) to run SmartUI tests on LambdaTest",
   "files": [
     "dist/**/*"

--- a/src/lib/ctx.ts
+++ b/src/lib/ctx.ts
@@ -23,6 +23,7 @@ export default (options: Record<string, string>): Context => {
     let fetchResultObj: boolean;
     let fetchResultsFileObj: string;
     let buildNameObj: string;
+    let allowDuplicateSnapshotNames: boolean = false;
     try {
         if (options.config) {
             config = JSON.parse(fs.readFileSync(options.config, 'utf-8'));
@@ -85,10 +86,13 @@ export default (options: Record<string, string>): Context => {
         }
     }
     if (config.basicAuthorization) {
-        basicAuthObj = config.basicAuthorization
+        basicAuthObj = config.basicAuthorization;
     }
     if (config.tunnel) {
-        tunnelObj = config.tunnel
+        tunnelObj = config.tunnel;
+    }
+    if (config.allowDuplicateSnapshotNames) {
+        allowDuplicateSnapshotNames = true;
     }
 
     return {
@@ -114,7 +118,8 @@ export default (options: Record<string, string>): Context => {
             skipBuildCreation: config.skipBuildCreation ?? false,
             tunnel: tunnelObj,
             userAgent: config.userAgent || '',
-            requestHeaders: config.requestHeaders || {}
+            requestHeaders: config.requestHeaders || {},
+            allowDuplicateSnapshotNames: allowDuplicateSnapshotNames,
         },
         uploadFilePath: '',
         webStaticConfig: [],

--- a/src/lib/schemaValidation.ts
+++ b/src/lib/schemaValidation.ts
@@ -258,6 +258,10 @@ const ConfigSchema = {
             errorMessage: {
                 uniqueItems: "Invalid config; duplicates in requestHeaders"
             }
+        },
+        allowDuplicateSnapshotNames: {
+            type: "boolean",
+            errorMessage: "Invalid config; allowDuplicateSnapshotNames must be true/false"
         }
     },
     anyOf: [

--- a/src/lib/snapshotQueue.ts
+++ b/src/lib/snapshotQueue.ts
@@ -276,7 +276,7 @@ export default class Queue {
                     this.ctx.log.info(`Processing Snapshot: ${snapshot?.name}`);
                 }
 
-                if (!this.ctx.config.delayedUpload && snapshot && snapshot.name && this.snapshotNames.includes(snapshot.name)) {
+                if (!this.ctx.config.delayedUpload && snapshot && snapshot.name && this.snapshotNames.includes(snapshot.name) && !this.ctx.config.allowDuplicateSnapshotNames) {
                     drop = true;
                     this.ctx.log.info(`Skipping duplicate SmartUI snapshot '${snapshot.name}'. To capture duplicate screenshots, please set the 'delayedUpload' configuration as true in your config file.`);
                 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,6 +36,7 @@ export interface Context {
         tunnel: tunnelConfig | undefined;
         userAgent?: string;
         requestHeaders?: Array<Record<string, string>>;
+        allowDuplicateSnapshotNames?: boolean;
     };
     uploadFilePath: string;
     webStaticConfig: WebStaticConfig;


### PR DESCRIPTION
This pull request introduces a new configuration option, `allowDuplicateSnapshotNames`, to provide users with more control over handling duplicate snapshot names in the application. The changes ensure that this option is integrated into the configuration schema, context, and snapshot processing logic.

### New Feature: `allowDuplicateSnapshotNames` Configuration

* **Context Initialization (`src/lib/ctx.ts`)**:
  - Added a new property, `allowDuplicateSnapshotNames`, to the context object, defaulting to `false`. This property is set based on the configuration file. [[1]](diffhunk://#diff-cd7d9408f570be42ab2291fee8d4aa34f0441dc28c5db303a9304b579fea58bcR26) [[2]](diffhunk://#diff-cd7d9408f570be42ab2291fee8d4aa34f0441dc28c5db303a9304b579fea58bcL88-R95) [[3]](diffhunk://#diff-cd7d9408f570be42ab2291fee8d4aa34f0441dc28c5db303a9304b579fea58bcL117-R122)

* **Configuration Schema Validation (`src/lib/schemaValidation.ts`)**:
  - Updated the schema to include `allowDuplicateSnapshotNames` as a boolean property, with an appropriate error message for invalid values.

* **Snapshot Processing Logic (`src/lib/snapshotQueue.ts`)**:
  - Modified the logic to skip duplicate snapshots only if `allowDuplicateSnapshotNames` is not enabled. This ensures that users can opt to allow duplicates if desired.

* **Type Definition (`src/types.ts`)**:
  - Updated the `Context` interface to include the optional `allowDuplicateSnapshotNames` property.