### PR TITLE
Add new ping test which uses default http client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 dist
+.idea
+*.tgz

--- a/src/commander/commander.ts
+++ b/src/commander/commander.ts
@@ -9,6 +9,7 @@ import startServer from './server.js';
 import stopServer from './stopServer.js'
 import ping from './ping.js'
 import merge from './merge.js'
+import pingTest from './pingTest.js'
 
 const program = new Command();
 
@@ -36,6 +37,7 @@ program
     .addCommand(configAppFigma)
     .addCommand(uploadWebFigmaCommand)
     .addCommand(uploadAppFigmaCommand)
+    .addCommand(pingTest)
 
 
 

--- a/src/commander/pingTest.ts
+++ b/src/commander/pingTest.ts
@@ -1,0 +1,85 @@
+import { Command } from 'commander';
+import * as http from 'http';
+import * as https from 'https';
+import chalk from 'chalk'
+
+function getSmartUIServerAddress() {
+    const serverAddress = process.env.SMARTUI_SERVER_ADDRESS || 'http://localhost:49152';
+    return serverAddress;
+}
+
+function makeHttpRequest(url: string, timeout: number): Promise<{ status: number; data: any }> {
+    return new Promise((resolve, reject) => {
+        const urlObj = new URL(url);
+        const isHttps = urlObj.protocol === 'https:';
+        const client = isHttps ? https : http;
+        
+        const req = client.request(url, { timeout }, (res) => {
+            let data = '';
+            
+            res.on('data', (chunk) => {
+                data += chunk;
+            });
+            
+            res.on('end', () => {
+                let parsedData;
+                try {
+                    parsedData = JSON.parse(data);
+                } catch {
+                    parsedData = data;
+                }
+                
+                resolve({
+                    status: res.statusCode || 0,
+                    data: parsedData
+                });
+            });
+        });
+        
+        req.on('error', (error) => {
+            reject(error);
+        });
+        
+        req.on('timeout', () => {
+            req.destroy();
+            const timeoutError = new Error('Request timeout');
+            (timeoutError as any).code = 'ECONNABORTED';
+            reject(timeoutError);
+        });
+        
+        req.end();
+    });
+}
+
+const command = new Command();
+
+command
+    .name('exec:pingTest')
+    .description('Ping the SmartUI server to check if it is running using default http client')
+    .action(async function(this: Command) {
+        try {
+            console.log(chalk.yellow("Pinging server using default http client..."));
+            const serverAddress = getSmartUIServerAddress();
+            console.log(chalk.yellow(`Pinging server at ${serverAddress} from terminal using default http client...`));
+
+            // Send GET request to the /ping endpoint
+            const response = await makeHttpRequest(`${serverAddress}/ping`, 15000);
+
+            // Log the response from the server
+            if (response.status === 200) {
+                console.log(chalk.green('SmartUI Server is running'));
+                console.log(chalk.green(`Response: ${JSON.stringify(response.data)}`)); // Log response data if needed
+            } else {
+                console.log(chalk.red('Failed to reach the server'));
+            }
+        } catch (error: any) {
+            // Handle any errors during the HTTP request
+            if (error.code === 'ECONNABORTED') {
+                console.error(chalk.red('Error: SmartUI server did not respond in 15 seconds'));
+            } else {
+                console.error(chalk.red('SmartUI server is not running'));
+            }
+        }
+    });
+
+export default command;


### PR DESCRIPTION
This pull request adds a new command to the CLI for checking the status of the SmartUI server using a direct HTTP request, and integrates it into the command registration. The main change is the introduction of the `pingTest` command, which provides a more robust way to verify server availability from the terminal.

### New CLI command for server health check

* Added a new file `src/commander/pingTest.ts` that defines the `exec:pingTest` command. This command sends a GET request to the `/ping` endpoint of the SmartUI server using Node's native HTTP/HTTPS modules, and provides colored output indicating the server status.
* Imported the new `pingTest` command in `src/commander/commander.ts` and registered it with the CLI program, making it available to users. [[1]](diffhunk://#diff-12ed1aa08dbbcaca41b0016d45417c3b6930bb72194361b1491267571c31052aR12) [[2]](diffhunk://#diff-12ed1aa08dbbcaca41b0016d45417c3b6930bb72194361b1491267571c31052aR40)