### PR TITLE
skip smartui logs file in exec:stop API

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lambdatest/smartui-cli",
-  "version": "4.1.26",
+  "version": "4.1.27",
   "description": "A command line interface (CLI) to run SmartUI tests on LambdaTest",
   "files": [
     "dist/**/*"

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -130,8 +130,9 @@ export default async (ctx: Context): Promise<FastifyInstance<Server, IncomingMes
 				let resp = await ctx.client.getS3PreSignedURL(ctx);
 				await ctx.client.uploadLogs(ctx, resp.data.url);
 			} else {
-				ctx.log.debug(`Log file to be uploaded via LSRS`)
-				let resp = ctx.client.sendCliLogsToLSRS(ctx);
+				ctx.log.debug(`Skipping upload of CLI logs as useLambdaInternal is set`)
+				// ctx.log.debug(`Log file to be uploaded via LSRS`)
+				// let resp = ctx.client.sendCliLogsToLSRS(ctx);
 			}
 
 			if (pingIntervalId !== null) {

--- a/src/lib/snapshotQueue.ts
+++ b/src/lib/snapshotQueue.ts
@@ -292,7 +292,7 @@ export default class Queue {
 
                 if (!this.ctx.config.delayedUpload && snapshot && snapshot.name && this.snapshotNames.includes(snapshot.name) && !this.ctx.config.allowDuplicateSnapshotNames) {
                     drop = true;
-                    this.ctx.log.info(`Skipping duplicate SmartUI snapshot '${snapshot.name}'. To capture duplicate screenshots, please set the 'delayedUpload' configuration as true in your config file.`);
+                    this.ctx.log.info(`Skipping duplicate SmartUI snapshot '${snapshot.name}'. To capture duplicate screenshots, please set the 'allowDuplicateSnapshotNames' or 'delayedUpload' configuration as true in your config file.`);
                 }
 
                 if (this.ctx.config.delayedUpload && snapshot && snapshot.name && this.snapshotNames.includes(snapshot.name)) {


### PR DESCRIPTION
This pull request includes a version bump and a few targeted improvements to log handling and snapshot deduplication messaging. The changes clarify configuration options and improve log messaging for users.

**Log handling improvements:**

* Changed the log upload logic in `src/lib/server.ts` to skip uploading CLI logs when `useLambdaInternal` is set, and updated the debug message to reflect this behavior.

**Snapshot deduplication messaging:**

* Updated the duplicate snapshot warning in `src/lib/snapshotQueue.ts` to mention both the `allowDuplicateSnapshotNames` and `delayedUpload` configuration options, providing clearer guidance to users.

**Version update:**

* Bumped the package version in `package.json` from `4.1.26` to `4.1.27`.