### PR TITLE
fix non git info

### DIFF
--- a/src/lib/git.ts
+++ b/src/lib/git.ts
@@ -17,11 +17,12 @@ function executeCommand(command: string): string {
 	}
 }
 
-export function isGitRepo(): boolean {
+export function isGitRepo(ctx: Context): boolean {
 	try {
 		executeCommand('git status')
 		return true
 	} catch (error) {
+		setNonGitInfo(ctx)
 		return false
 	}
 }
@@ -82,3 +83,25 @@ export default (ctx: Context): Git => {
 		};
 	}
 }
+
+
+function setNonGitInfo(ctx: Context) {
+	let branch = ctx.env.CURRENT_BRANCH || 'unknown-branch'
+	if (ctx.options.markBaseline) {
+		ctx.env.BASELINE_BRANCH = branch
+		ctx.env.SMART_GIT = false
+	}
+	let githubURL;
+	if (ctx.options.githubURL && ctx.options.githubURL.startsWith('https://')) {
+		githubURL = ctx.options.githubURL;
+	}
+
+	ctx.git = {
+		branch: branch,
+		commitId: '-',
+		commitAuthor: '-',
+		commitMessage: '-',
+		githubURL: githubURL? githubURL : '',
+		baselineBranch: ctx.options.baselineBranch || ctx.env.BASELINE_BRANCH || ''
+	}
+}	

--- a/src/tasks/getGitInfo.ts
+++ b/src/tasks/getGitInfo.ts
@@ -7,7 +7,7 @@ export default (ctx: Context): ListrTask<Context, ListrRendererFactory, ListrRen
     return {
         title: `Fetching git repo details`,
         skip: (ctx): string => {
-            return (!isGitRepo() && !ctx.env.SMARTUI_GIT_INFO_FILEPATH) ? '[SKIPPED] Fetching git repo details; not a git repo' : '';
+            return (!isGitRepo(ctx) && !ctx.env.SMARTUI_GIT_INFO_FILEPATH) ? '[SKIPPED] Fetching git repo details; not a git repo' : '';
         },
         task: async (ctx, task): Promise<void> => {
             if (ctx.env.CURRENT_BRANCH && ctx.env.CURRENT_BRANCH.trim() === '') {


### PR DESCRIPTION
This pull request improves how the application handles cases where the current directory is not a Git repository. The main changes ensure that relevant context information is set when Git is unavailable, and update related functions to support this behavior.

**Handling non-Git repository scenarios:**

* The `isGitRepo` function in `src/lib/git.ts` now accepts a `Context` object and calls `setNonGitInfo` to update context when the directory is not a Git repo.
* Added a new `setNonGitInfo` function in `src/lib/git.ts` to populate `ctx.git` with default values and handle baseline branch and GitHub URL logic when Git is unavailable.

**Function signature and usage updates:**

* Updated the usage of `isGitRepo` in `src/tasks/getGitInfo.ts` to pass the context object, ensuring consistent handling of non-Git scenarios throughout the codebase.