### PR TITLE
DOT-5874: Refactor PDF result fetching and enhance error handling for project ID

### DIFF
--- a/src/lib/httpClient.ts
+++ b/src/lib/httpClient.ts
@@ -686,22 +686,20 @@ export default class httpClient {
     }
 
     async fetchPdfResults(ctx: Context): Promise<any> {
-        const params: Record<string, string> = {
-            projectToken: this.projectToken
-        };
+        const params: Record<string, string> = {};
 
-        // Use buildId if available, otherwise use buildName
-        if (ctx.build.id) {
-            params.buildId = ctx.build.id;
-        } else if (ctx.build.name) {
-            params.buildName = ctx.build.name;
+        if (ctx.build.projectId) {
+            params.project_id = ctx.build.projectId;
+        } else {
+            throw new Error('Project ID not found to fetch PDF results');
         }
+        params.build_id = ctx.build.id;
 
         const auth = Buffer.from(`${this.username}:${this.accessKey}`).toString('base64');
 
         try {
             const response = await axios.request({
-                url: ctx.env.SMARTUI_UPLOAD_URL + '/automation/smart-ui/screenshot/build/status',
+                url: ctx.env.SMARTUI_UPLOAD_URL + '/smartui/2.0/build/screenshots',
                 method: 'GET',
                 params: params,
                 headers: {

--- a/src/tasks/uploadPdfs.ts
+++ b/src/tasks/uploadPdfs.ts
@@ -55,6 +55,9 @@ async function uploadPdfs(ctx: Context, pdfPath: string): Promise<void> {
             ctx.build.id = response.buildId;
             ctx.log.debug(`PDF upload successful. Build ID: ${ctx.build.id}`);
         }
+        if (response && response.projectId) {
+            ctx.build.projectId = response.projectId;
+        }
     } catch (error : any) {
         throw new Error(error.message);
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -181,6 +181,7 @@ export interface Build {
     baseline: boolean;
     useKafkaFlow: boolean;
     hasDiscoveryError: boolean;
+    projectId?: string;
 }
 
 export interface WebConfig {


### PR DESCRIPTION
This pull request updates the PDF results polling and processing logic to align with a new API response format and improves the reliability and clarity of PDF test result reporting. The main changes involve updating field names to match the new API, ensuring required identifiers are present, and improving the structure of result handling.

**API Integration and Data Structure Updates:**

* Updated the `fetchPdfResults` method in `httpClient` to use the new endpoint (`/smartui/2.0/build/screenshots`), require `project_id` and `build_id` in request parameters, and handle missing `projectId` with an explicit error.
* Added `projectId` to the `Build` interface and ensured it is set after PDF upload, so subsequent API calls have the required context. [[1]](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aR184) [[2]](diffhunk://#diff-a65630d44c91920ec4735ac59a6f598cf63709549a5428004a01619d6166da44R58-R60)

**Field Name and Data Mapping Adjustments:**

* Refactored all usages of screenshot and build fields (e.g., `screenshotName` → `screenshot_name`, `mismatchPercentage` → `mismatch_percentage`, etc.) throughout the polling and grouping utilities to match the new API response structure. [[1]](diffhunk://#diff-da10bcc7d8dff796f50c9358a7268eb5abd2c50f460aecc4b2be1c691a966224L529-R576) [[2]](diffhunk://#diff-da10bcc7d8dff796f50c9358a7268eb5abd2c50f460aecc4b2be1c691a966224L628-R621) [[3]](diffhunk://#diff-da10bcc7d8dff796f50c9358a7268eb5abd2c50f460aecc4b2be1c691a966224L644-R637) [[4]](diffhunk://#diff-da10bcc7d8dff796f50c9358a7268eb5abd2c50f460aecc4b2be1c691a966224L653-R646) [[5]](diffhunk://#diff-da10bcc7d8dff796f50c9358a7268eb5abd2c50f460aecc4b2be1c691a966224L662-R659)
* Updated how build and project names are accessed in logs and outputs to use the new nested structure in the API response.

**Polling Logic and Output Improvements:**

* Increased the maximum polling attempts to 60 for improved reliability and simplified error handling for failed fetches. [[1]](diffhunk://#diff-da10bcc7d8dff796f50c9358a7268eb5abd2c50f460aecc4b2be1c691a966224L529-R576) [[2]](diffhunk://#diff-da10bcc7d8dff796f50c9358a7268eb5abd2c50f460aecc4b2be1c691a966224L591-L596)
* Improved the formatting and clarity of PDF test summary output, including more accurate mismatch reporting and clearer grouping by PDF. [[1]](diffhunk://#diff-da10bcc7d8dff796f50c9358a7268eb5abd2c50f460aecc4b2be1c691a966224L529-R576) [[2]](diffhunk://#diff-da10bcc7d8dff796f50c9358a7268eb5abd2c50f460aecc4b2be1c691a966224L662-R659)