### PR TITLE
overrides simple-swizzle version to 0.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,9 @@
     "which": "^4.0.0",
     "winston": "^3.10.0"
   },
+  "overrides": {
+    "simple-swizzle": "0.2.2"
+  },
   "devDependencies": {
     "typescript": "^5.3.2"
   }


### PR DESCRIPTION
This pull request introduces a dependency override in the `package.json` file to address package resolution for `simple-swizzle`.

Dependency management:

* Added an `overrides` section to `package.json` to force the use of version `0.2.2` of the `simple-swizzle` package.