### PR TITLE
DOT-6319: Add support for custom cookies 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lambdatest/smartui-cli",
-  "version": "4.1.34",
+  "version": "4.1.35",
   "description": "A command line interface (CLI) to run SmartUI tests on LambdaTest",
   "files": [
     "dist/**/*"

--- a/src/lib/processSnapshot.ts
+++ b/src/lib/processSnapshot.ts
@@ -243,6 +243,47 @@ export default async function processSnapshot(snapshot: Snapshot, ctx: Context):
             ctx.log.debug('No valid cookies to add');
         }
     }
+
+    let options = snapshot.options;
+
+    // Custom cookies include those which cannot be captured by javascript function `document.cookie` like httpOnly, secure, sameSite etc.
+    // These custom cookies will be captured by the user in their automation browser and sent to CLI through the snapshot options using `customCookies` field.
+    if (options?.customCookies && Array.isArray(options.customCookies) && options.customCookies.length > 0) {
+        ctx.log.debug(`Setting ${options.customCookies.length} custom cookies`);
+        
+        const validCustomCookies = options.customCookies.filter(cookie => {
+            if (!cookie.name || !cookie.value || !cookie.domain) {
+                ctx.log.debug(`Skipping invalid custom cookie: missing required fields (name, value, or domain)`);
+                return false;
+            }
+            
+            if (cookie.sameSite && !['Strict', 'Lax', 'None'].includes(cookie.sameSite)) {
+                ctx.log.debug(`Skipping invalid custom cookie: invalid sameSite value '${cookie.sameSite}'`);
+                return false;
+            }
+            
+            return true;
+        }).map(cookie => ({
+            name: cookie.name,
+            value: cookie.value,
+            domain: cookie.domain,
+            path: cookie.path || '/',
+            httpOnly: cookie.httpOnly || false,
+            secure: cookie.secure || false,
+            sameSite: cookie.sameSite || 'Lax'
+        }));
+
+        if (validCustomCookies.length > 0) {
+            try {
+                await context.addCookies(validCustomCookies);
+                ctx.log.debug(`Successfully added ${validCustomCookies.length} custom cookies`);
+            } catch (error) {
+                ctx.log.debug(`Failed to add custom cookies: ${error}`);
+            }
+        } else {
+            ctx.log.debug('No valid custom cookies to add');
+        }
+    }
     const page = await context.newPage();
 
     // populate cache with already captured resources
@@ -415,8 +456,6 @@ export default async function processSnapshot(snapshot: Snapshot, ctx: Context):
             route.abort();
         }
     });
-
-    let options = snapshot.options;
     let optionWarnings: Set<string> = new Set();
     let selectors: Array<string> = [];
     let ignoreOrSelectDOM: string;
@@ -582,6 +621,7 @@ export default async function processSnapshot(snapshot: Snapshot, ctx: Context):
                 // adding extra timeout since domcontentloaded event is fired pretty quickly
                 await new Promise(r => setTimeout(r, 1250));
                 if (ctx.config.waitForTimeout) await page.waitForTimeout(ctx.config.waitForTimeout);
+                await page.waitForLoadState("networkidle", { timeout: 30000 }).catch(() => { ctx.log.debug('networkidle event failed to fire within 30s') });
                 navigated = true;
                 ctx.log.debug(`Navigated to ${snapshot.url}`);
             } catch (error: any) {
@@ -815,7 +855,6 @@ export default async function processSnapshot(snapshot: Snapshot, ctx: Context):
 
     if (hasBrowserErrors) {
         discoveryErrors.timestamp = new Date().toISOString();
-        // ctx.log.warn(discoveryErrors);
     }
 
     if (ctx.config.useGlobalCache) {

--- a/src/lib/processSnapshot.ts
+++ b/src/lib/processSnapshot.ts
@@ -621,7 +621,7 @@ export default async function processSnapshot(snapshot: Snapshot, ctx: Context):
                 // adding extra timeout since domcontentloaded event is fired pretty quickly
                 await new Promise(r => setTimeout(r, 1250));
                 if (ctx.config.waitForTimeout) await page.waitForTimeout(ctx.config.waitForTimeout);
-                await page.waitForLoadState("networkidle", { timeout: 30000 }).catch(() => { ctx.log.debug('networkidle event failed to fire within 30s') });
+                await page.waitForLoadState("networkidle", { timeout: 10000 }).catch(() => { ctx.log.debug('networkidle event failed to fire within 10s') });
                 navigated = true;
                 ctx.log.debug(`Navigated to ${snapshot.url}`);
             } catch (error: any) {

--- a/src/lib/schemaValidation.ts
+++ b/src/lib/schemaValidation.ts
@@ -582,6 +582,14 @@ const SnapshotSchema: JSONSchemaType<Snapshot> = {
                     minimum: 0,
                     maximum: 100,
                     errorMessage: "Invalid snapshot options; rejectionThreshold must be a number between 0 and 100"
+                },
+                customCookies: {
+                    type: "array",
+                    items: {
+                        type: "object",
+                        minProperties: 1,
+                    },
+                    errorMessage: "Invalid snapshot options; customCookies must be an array of objects with string properties"
                 }
             },
             additionalProperties: false

--- a/src/types.ts
+++ b/src/types.ts
@@ -164,6 +164,7 @@ export interface Snapshot {
         useExtendedViewport?: boolean;
         approvalThreshold?: number;
         rejectionThreshold?: number;
+        customCookies?: CustomCookie[];
     }
 }
 
@@ -249,6 +250,16 @@ export interface tunnelConfig {
 export interface FigmaWebConfig {
     autoDetectViewports: Array<string>;
     configs: Array<{ figma_file_token: string, figma_ids: Array<string>, screenshot_names:Array<string> }>;
+}
+
+export interface CustomCookie {
+    name: string;
+    value: string;
+    domain: string;
+    path: string;
+    httpOnly: boolean;
+    secure: boolean;
+    sameSite: 'Strict' | 'Lax' | 'None';
 }
 
 


### PR DESCRIPTION
This pull request adds support for handling custom cookies in the snapshot processing workflow, allowing cookies that can't be set via JavaScript (such as httpOnly, secure, and sameSite variants) to be injected via the snapshot options. It also introduces schema validation for these custom cookies and improves navigation reliability by waiting for the network to become idle after navigation.

**Custom Cookies Support:**

* Added a `customCookies` field to the `Snapshot` options, allowing users to specify cookies (including httpOnly, secure, and sameSite) that are not accessible via `document.cookie`. These cookies are validated for required fields and correct `sameSite` values before being set in the browser context. [[1]](diffhunk://#diff-f4a0a71049dc071dc081c306fc77a6494d9294d936aa10a1dee4dee8c1465b31R246-R286) [[2]](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aR167) [[3]](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aR255-R264)
* Updated the JSON schema validation to include the `customCookies` array, ensuring the structure and types of custom cookies are checked before processing.

**Navigation Reliability:**

* After navigation, added a wait for the `networkidle` state (with a 30s timeout) to ensure the page has finished loading resources, improving the reliability of snapshot captures.

**Minor Code Quality Improvements:**

* Removed an unused or redundant variable assignment and cleaned up commented code for better maintainability. [[1]](diffhunk://#diff-f4a0a71049dc071dc081c306fc77a6494d9294d936aa10a1dee4dee8c1465b31L418-L419) [[2]](diffhunk://#diff-f4a0a71049dc071dc081c306fc77a6494d9294d936aa10a1dee4dee8c1465b31L818)