### PR TITLE
4.1.37-beta.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lambdatest/smartui-cli",
-  "version": "4.1.36",
+  "version": "4.1.37-beta.0",
   "description": "A command line interface (CLI) to run SmartUI tests on LambdaTest",
   "files": [
     "dist/**/*"

--- a/src/lib/httpClient.ts
+++ b/src/lib/httpClient.ts
@@ -375,7 +375,7 @@ export default class httpClient {
         }, ctx.log)
     }
 
-    processSnapshotCaps(ctx: Context, snapshot: ProcessedSnapshot, snapshotUuid: string, capsBuildId: string, capsProjectToken: string, discoveryErrors: DiscoveryErrors) {
+    processSnapshotCaps(ctx: Context, snapshot: ProcessedSnapshot, snapshotUuid: string, capsBuildId: string, capsProjectToken: string, discoveryErrors: DiscoveryErrors, variantCount: number, sync: boolean = false) {
         return this.request({
             url: `/build/${capsBuildId}/snapshot`,
             method: 'POST',
@@ -387,17 +387,19 @@ export default class httpClient {
                 name: snapshot.name,
                 url: snapshot.url,
                 snapshotUuid: snapshotUuid,
+                variantCount: variantCount,
                 test: {
                     type: ctx.testType,
                     source: 'cli'
                 },
                 doRemoteDiscovery: snapshot.options.doRemoteDiscovery,
                 discoveryErrors: discoveryErrors,
+                sync: sync
             }
         }, ctx.log)
     }
 
-    uploadSnapshotForCaps(ctx: Context, snapshot: ProcessedSnapshot, capsBuildId: string, capsProjectToken: string, discoveryErrors: DiscoveryErrors) {
+    uploadSnapshotForCaps(ctx: Context, snapshot: ProcessedSnapshot, capsBuildId: string, capsProjectToken: string, discoveryErrors: DiscoveryErrors, variantCount: number, sync: boolean = false) {
         // Use capsBuildId if provided, otherwise fallback to ctx.build.id
         const buildId = capsBuildId !== '' ? capsBuildId : ctx.build.id;
     
@@ -415,6 +417,8 @@ export default class httpClient {
                     source: 'cli'
                 },
                 discoveryErrors: discoveryErrors,
+                variantCount: variantCount,
+                sync: sync
             }
         }, ctx.log);
     }
@@ -660,9 +664,9 @@ export default class httpClient {
         }, ctx.log)
     }
 
-    getSnapshotStatus(snapshotName: string, snapshotUuid: string, ctx: Context): Promise<Record<string, any>> {
+    getSnapshotStatus(buildId: string, snapshotName: string, snapshotUuid: string, ctx: Context): Promise<Record<string, any>> {
         return this.request({
-            url: `/snapshot/status?buildId=${ctx.build.id}&snapshotName=${snapshotName}&snapshotUUID=${snapshotUuid}`,
+            url: `/snapshot/status?buildId=${buildId}&snapshotName=${snapshotName}&snapshotUUID=${snapshotUuid}`,
             method: 'GET',
             headers: {
                 'Content-Type': 'application/json',

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -252,18 +252,28 @@ export default async (ctx: Context): Promise<FastifyInstance<Server, IncomingMes
 			if (ctx.contextToSnapshotMap?.has(contextId)) {
 				let contextStatus = ctx.contextToSnapshotMap.get(contextId);
 				
-				while (contextStatus==0) {
+				let counter= 60;
+				while (contextStatus==='0') {
+					if(counter<=0){
+						throw new Error('Snapshot processing failed');
+					}
 					// Wait 5 seconds before next check
 					await new Promise(resolve => setTimeout(resolve, 5000));
 					
 					contextStatus = ctx.contextToSnapshotMap.get(contextId);
+					counter--;
 				}
 
-				if(contextStatus==2){
+				if(contextStatus==='2'){
 					throw new Error("Snapshot Failed");
 				}
 				
 				ctx.log.debug("Snapshot uploaded successfully");
+
+				const buildId = contextStatus;
+				if (!buildId) {
+					throw new Error(`No buildId found for contextId: ${contextId}`);
+				}
 
 				// Poll external API until it returns 200 or timeout is reached
 				let lastExternalResponse: any = null; 
@@ -272,6 +282,7 @@ export default async (ctx: Context): Promise<FastifyInstance<Server, IncomingMes
 				while (true) {
 					try {
 						const externalResponse = await ctx.client.getSnapshotStatus(
+							buildId,
 							snapshotName,
 							contextId,
 							ctx

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -118,7 +118,7 @@ export default async (ctx: Context): Promise<FastifyInstance<Server, IncomingMes
 			}
 			
 			if (contextId && ctx.contextToSnapshotMap) {
-				ctx.contextToSnapshotMap.set(contextId, 0);
+				ctx.contextToSnapshotMap.set(contextId, '0');
 				ctx.log.debug(`Marking contextId as captured and added to queue: ${contextId}`);
 			}
 
@@ -257,10 +257,9 @@ export default async (ctx: Context): Promise<FastifyInstance<Server, IncomingMes
 					if(counter<=0){
 						throw new Error('Snapshot processing failed');
 					}
+					contextStatus = ctx.contextToSnapshotMap.get(contextId);
 					// Wait 5 seconds before next check
 					await new Promise(resolve => setTimeout(resolve, 5000));
-					
-					contextStatus = ctx.contextToSnapshotMap.get(contextId);
 					counter--;
 				}
 

--- a/src/lib/snapshotQueue.ts
+++ b/src/lib/snapshotQueue.ts
@@ -364,7 +364,10 @@ export default class Queue {
                     if (useCapsBuildId) {
                         this.ctx.log.info(`Using cached buildId: ${capsBuildId}`);
                         if (useKafkaFlowCaps) {
-                            const snapshotUuid = uuidv4();
+                            let snapshotUuid = uuidv4();
+                            if (snapshot?.options?.contextId && this.ctx.contextToSnapshotMap?.has(snapshot.options.contextId)) {
+                                snapshotUuid = snapshot.options.contextId;
+                             }
                             let uploadDomToS3 = this.ctx.config.useLambdaInternal || uploadDomToS3ViaEnv;
                             if (!uploadDomToS3) {
                                 this.ctx.log.debug(`Uploading dom to S3 for snapshot using presigned URL for CAPS`);
@@ -375,9 +378,9 @@ export default class Queue {
                                 this.ctx.log.debug(`Uploading dom to S3 for snapshot using LSRS`);
                                 await this.ctx.client.sendDomToLSRSForCaps(this.ctx, processedSnapshot, snapshotUuid, capsBuildId, capsProjectToken);
                             }
-                            await this.ctx.client.processSnapshotCaps(this.ctx, processedSnapshot, snapshotUuid, capsBuildId, capsProjectToken, discoveryErrors);
+                            await this.ctx.client.processSnapshotCaps(this.ctx, processedSnapshot, snapshotUuid, capsBuildId, capsProjectToken, discoveryErrors, calculateVariantCountFromSnapshot(processedSnapshot, this.ctx.config), snapshot?.options?.sync);
                         } else {
-                            await this.ctx.client.uploadSnapshotForCaps(this.ctx, processedSnapshot, capsBuildId, capsProjectToken, discoveryErrors);
+                            await this.ctx.client.uploadSnapshotForCaps(this.ctx, processedSnapshot, capsBuildId, capsProjectToken, discoveryErrors, calculateVariantCountFromSnapshot(processedSnapshot, this.ctx.config), snapshot?.options?.sync);
                         }
 
                         // Increment snapshot count for the specific buildId
@@ -385,6 +388,10 @@ export default class Queue {
                         const currentCount = cachedCapabilities?.snapshotCount || 0; // Get the current snapshot count for sessionId
                         cachedCapabilities.snapshotCount = currentCount + 1; // Increment snapshot count
                         this.ctx.sessionCapabilitiesMap.set(sessionId, cachedCapabilities);
+
+                        if (snapshot?.options?.contextId && this.ctx.contextToSnapshotMap) {
+                            this.ctx.contextToSnapshotMap.set(snapshot.options.contextId, capsBuildId);
+                        }
                     } else {
                         if (!this.ctx.build?.id) {
                             if (this.ctx.authenticatedInitially) {
@@ -440,7 +447,7 @@ export default class Queue {
                                     }
                                 }
                                 if(snapshot?.options?.contextId){
-                                    this.ctx.contextToSnapshotMap?.set(snapshot?.options?.contextId,2);
+                                    this.ctx.contextToSnapshotMap?.set(snapshot?.options?.contextId,'2');
                                 }
                                 this.processNext();
                             } else {
@@ -448,7 +455,7 @@ export default class Queue {
                                 let rejectionThreshold = snapshot?.options?.rejectionThreshold || this.ctx.config.rejectionThreshold;
                                 await this.ctx.client.processSnapshot(this.ctx, processedSnapshot, snapshotUuid, discoveryErrors,calculateVariantCountFromSnapshot(processedSnapshot, this.ctx.config),snapshot?.options?.sync, approvalThreshold, rejectionThreshold);
                                 if(snapshot?.options?.contextId && this.ctx.contextToSnapshotMap?.has(snapshot.options.contextId)){
-                                    this.ctx.contextToSnapshotMap.set(snapshot.options.contextId, 1);
+                                    this.ctx.contextToSnapshotMap.set(snapshot.options.contextId, this.ctx.build.id);
                                 }
                                 this.ctx.log.debug(`ContextId: ${snapshot?.options?.contextId} status set to uploaded`);
                             }
@@ -465,7 +472,7 @@ export default class Queue {
                 this.ctx.log.debug(`snapshot failed; ${error}`);
                 this.processedSnapshots.push({ name: snapshot?.name, error: error.message });
                 if (snapshot?.options?.contextId && this.ctx.contextToSnapshotMap) {
-                    this.ctx.contextToSnapshotMap.set(snapshot.options.contextId, 2);
+                    this.ctx.contextToSnapshotMap.set(snapshot.options.contextId, '2');
                 }
             }
             // Close open browser contexts and pages

--- a/src/types.ts
+++ b/src/types.ts
@@ -93,7 +93,7 @@ export interface Context {
     mergeBuildTargetId?: string;
     mergeByBranch?: boolean;
     mergeByBuild?: boolean;
-    contextToSnapshotMap?: Map<string, number>;
+    contextToSnapshotMap?: Map<string, string>;
     sourceCommand?: string;
     autoTunnelStarted?: boolean;
 }


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes related to snapshot processing, status tracking, and build context management in the SmartUI CLI. The changes primarily focus on making the context-to-snapshot mapping more robust by switching status tracking from numeric codes to string-based identifiers, improving reliability in snapshot status polling, and enhancing API request payloads with additional metadata.

Key changes include:

**Context and Snapshot Status Management:**

* The `contextToSnapshotMap` now uses string values (such as build IDs or status codes as strings) instead of numbers to track the status of each context, improving clarity and consistency in status handling throughout the codebase. [[1]](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aL96-R96) [[2]](diffhunk://#diff-51d82a57974c308e63bb067081b8a1f46af5b01943a736cd67f2d2ce4f8debb3L121-R121) [[3]](diffhunk://#diff-dda138c8b33201a3a0aa87851b8d9093f132ef73c8a8fe59e0f776bdefa50ac9L443-R458) [[4]](diffhunk://#diff-dda138c8b33201a3a0aa87851b8d9093f132ef73c8a8fe59e0f776bdefa50ac9L468-R475)
* The snapshot status polling logic in `server.ts` is updated to handle string statuses, includes a timeout mechanism, and now retrieves the correct build ID from the map for external status checks.

**Snapshot Processing and API Enhancements:**

* The `processSnapshotCaps` and `uploadSnapshotForCaps` methods in `httpClient.ts` now accept `variantCount` and `sync` parameters, and these values are included in the API request payloads, providing more detailed context for snapshot processing. [[1]](diffhunk://#diff-06bc301f8825801df12d51f0218c8484bd810822b95d346565ef033ac97c1f49L378-R378) [[2]](diffhunk://#diff-06bc301f8825801df12d51f0218c8484bd810822b95d346565ef033ac97c1f49R390-R402) [[3]](diffhunk://#diff-06bc301f8825801df12d51f0218c8484bd810822b95d346565ef033ac97c1f49R420-R421)
* When using Kafka Flow with capabilities, the snapshot UUID is now set to the context ID if available, ensuring better traceability between contexts and snapshots.

**API Request Improvements:**

* The `getSnapshotStatus` method now requires an explicit `buildId` parameter, rather than relying on `ctx.build.id`, making the method more flexible and accurate in multi-build scenarios.

**Miscellaneous:**

* The package version is bumped to `4.1.37-beta.0`.

These changes collectively improve the reliability and traceability of snapshot handling, especially in parallel and distributed test execution environments.