### PR TITLE
Release 4.1.38-beta.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lambdatest/smartui-cli",
-  "version": "4.1.37",
+  "version": "4.1.38-beta.1",
   "description": "A command line interface (CLI) to run SmartUI tests on LambdaTest",
   "files": [
     "dist/**/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lambdatest/smartui-cli",
-  "version": "4.1.38-beta.1",
+  "version": "4.1.38-beta.0",
   "description": "A command line interface (CLI) to run SmartUI tests on LambdaTest",
   "files": [
     "dist/**/*"

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -24,7 +24,8 @@ export default (): Env => {
         USE_REMOTE_DISCOVERY,
         SMART_GIT,
         SHOW_RENDER_ERRORS,
-        SMARTUI_SSE_URL='https://server-events.lambdatest.com'
+        SMARTUI_SSE_URL='https://server-events.lambdatest.com',
+        LT_SDK_SKIP_EXECUTION_LOGS
     } = process.env
         
     return {
@@ -50,6 +51,7 @@ export default (): Env => {
         USE_REMOTE_DISCOVERY: USE_REMOTE_DISCOVERY === 'true',
         SMART_GIT: SMART_GIT === 'true',
         SHOW_RENDER_ERRORS: SHOW_RENDER_ERRORS === 'true',
-        SMARTUI_SSE_URL
+        SMARTUI_SSE_URL,
+        LT_SDK_SKIP_EXECUTION_LOGS: LT_SDK_SKIP_EXECUTION_LOGS === 'true'
     }
 }

--- a/src/tasks/exec.ts
+++ b/src/tasks/exec.ts
@@ -31,12 +31,14 @@ export default (ctx: Context): ListrTask<Context, ListrRendererFactory, ListrRen
 
                 // Handle standard output
                 let totalOutput = '';
-                const output = createWritable((chunk: string) => {
-                    totalOutput += chunk;
-                    task.output = chalk.gray(totalOutput);
-                })
-                childProcess.stdout?.pipe(output);
-                childProcess.stderr?.pipe(output);
+                if (!ctx.env.LT_SDK_SKIP_EXECUTION_LOGS) {
+                    const output = createWritable((chunk: string) => {
+                        totalOutput += chunk;
+                        task.output = chalk.gray(totalOutput);
+                    })
+                    childProcess.stdout?.pipe(output);
+                    childProcess.stderr?.pipe(output);
+                }
 
                 childProcess.on('error', (error) => {
                     task.output = chalk.gray(`error: ${error.message}`);

--- a/src/types.ts
+++ b/src/types.ts
@@ -124,6 +124,7 @@ export interface Env {
     SMART_GIT: boolean;
     SHOW_RENDER_ERRORS: boolean;
     SMARTUI_SSE_URL: string;
+    LT_SDK_SKIP_EXECUTION_LOGS: boolean;
 }
 
 export interface Snapshot {


### PR DESCRIPTION
This pull request introduces a new environment variable, `LT_SDK_SKIP_EXECUTION_LOGS`, which allows users to control whether execution logs from the SDK are displayed during task execution. The implementation updates the environment handling, task execution logic, and type definitions to support this feature. The package version is also bumped to a beta release.

**Feature: Execution Log Skipping**

* Added support for the `LT_SDK_SKIP_EXECUTION_LOGS` environment variable in `src/lib/env.ts`, parsing it as a boolean and including it in the returned environment object. [[1]](diffhunk://#diff-48fc28ac09c5305215c9178154a6caf8eedb90e42e44183606e9f2ad20311e46L27-R28) [[2]](diffhunk://#diff-48fc28ac09c5305215c9178154a6caf8eedb90e42e44183606e9f2ad20311e46L53-R55)
* Updated the `Env` interface in `src/types.ts` to include the new `LT_SDK_SKIP_EXECUTION_LOGS` boolean property.
* Modified `src/tasks/exec.ts` so that standard output and error logs are only piped and displayed if `LT_SDK_SKIP_EXECUTION_LOGS` is not set to true.

**Other changes**

* Bumped the package version to `4.1.38-beta.0` in `package.json` to reflect the new feature and beta status.