### PR TITLE
TE-2129: add customViewports support for per-browser viewport config

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lambdatest/smartui-cli",
-  "version": "4.1.55",
+  "version": "4.1.56",
   "description": "A command line interface (CLI) to run SmartUI tests on LambdaTest",
   "files": [
     "dist/**/*"

--- a/src/lib/ctx.ts
+++ b/src/lib/ctx.ts
@@ -105,7 +105,12 @@ export default (options: Record<string, string>): Context => {
     }
 
     if (config.web) {
-        if (config.web.customViewports && Array.isArray(config.web.customViewports) && config.web.customViewports.length > 0) {
+        const hasCustomViewports = config.web.customViewports && Array.isArray(config.web.customViewports) && config.web.customViewports.length > 0;
+        const hasBrowsersAndViewports = config.web.browsers && config.web.browsers.length > 0 && config.web.viewports && config.web.viewports.length > 0;
+        if (!hasCustomViewports && !hasBrowsersAndViewports) {
+            throw new Error('Invalid config; web config must have either customViewports or both browsers and viewports');
+        }
+        if (hasCustomViewports) {
             const browserViewports: Record<string, Array<{ width: number, height: number }>> = {};
             for (const entry of config.web.customViewports) {
                 const vp = { width: entry.viewport[0], height: entry.viewport[1] || 0 };

--- a/src/lib/ctx.ts
+++ b/src/lib/ctx.ts
@@ -105,8 +105,29 @@ export default (options: Record<string, string>): Context => {
     }
 
     if (config.web) {
-        webConfig = { browsers: config.web.browsers, viewports: [] };
-        for (let viewport of config.web?.viewports) webConfig.viewports.push({ width: viewport[0], height: viewport[1] || 0 });
+        if (config.web.customViewports && Array.isArray(config.web.customViewports) && config.web.customViewports.length > 0) {
+            const browserViewports: Record<string, Array<{ width: number, height: number }>> = {};
+            for (const entry of config.web.customViewports) {
+                const vp = { width: entry.viewport[0], height: entry.viewport[1] || 0 };
+                if (!browserViewports[entry.browser]) browserViewports[entry.browser] = [];
+                if (!browserViewports[entry.browser].some(v => v.width === vp.width && v.height === vp.height)) {
+                    browserViewports[entry.browser].push(vp);
+                }
+            }
+            const browsers = Object.keys(browserViewports);
+            const allViewports: Array<{ width: number, height: number }> = [];
+            for (const vps of Object.values(browserViewports)) {
+                for (const vp of vps) {
+                    if (!allViewports.some(v => v.width === vp.width && v.height === vp.height)) {
+                        allViewports.push(vp);
+                    }
+                }
+            }
+            webConfig = { browsers, viewports: allViewports, browserViewports };
+        } else {
+            webConfig = { browsers: config.web.browsers, viewports: [] };
+            for (let viewport of config.web?.viewports) webConfig.viewports.push({ width: viewport[0], height: viewport[1] || 0 });
+        }
     }
     if (config.mobile) {
         mobileConfig = {

--- a/src/lib/ctx.ts
+++ b/src/lib/ctx.ts
@@ -126,7 +126,9 @@ export default (options: Record<string, string>): Context => {
             webConfig = { browsers, viewports: allViewports, browserViewports };
         } else {
             webConfig = { browsers: config.web.browsers, viewports: [] };
-            for (let viewport of config.web?.viewports) webConfig.viewports.push({ width: viewport[0], height: viewport[1] || 0 });
+            if (config.web?.viewports) {
+                for (let viewport of config.web.viewports) webConfig.viewports.push({ width: viewport[0], height: viewport[1] || 0 });
+            }
         }
     }
     if (config.mobile) {

--- a/src/lib/processSnapshot.ts
+++ b/src/lib/processSnapshot.ts
@@ -158,9 +158,16 @@ export async function prepareSnapshot(snapshot: Snapshot, ctx: Context): Promise
         }
     }
 
-    // Global browserViewports fallback — runs when options is empty or has no web override
+    // Global config fallback — runs when options is empty or has no web/mobile override
     if (!processedOptions.web && ctx.config.web?.browserViewports) {
         processedOptions.web = { browserViewports: ctx.config.web.browserViewports };
+    }
+    if (!processedOptions.mobile && ctx.config.mobile) {
+        processedOptions.mobile = {
+            devices: ctx.config.mobile.devices,
+            fullPage: ctx.config.mobile.fullPage ?? true,
+            orientation: ctx.config.mobile.orientation || constants.MOBILE_ORIENTATION_PORTRAIT
+        };
     }
 
     if (ctx.config.tunnel) {
@@ -649,9 +656,16 @@ export default async function processSnapshot(snapshot: Snapshot, ctx: Context):
         }
     }
 
-    // Global browserViewports fallback — runs when options is empty or has no web override
+    // Global config fallback — runs when options is empty or has no web/mobile override
     if (!processedOptions.web && ctx.config.web?.browserViewports) {
         processedOptions.web = { browserViewports: ctx.config.web.browserViewports };
+    }
+    if (!processedOptions.mobile && ctx.config.mobile) {
+        processedOptions.mobile = {
+            devices: ctx.config.mobile.devices,
+            fullPage: ctx.config.mobile.fullPage ?? true,
+            orientation: ctx.config.mobile.orientation || constants.MOBILE_ORIENTATION_PORTRAIT
+        };
     }
 
     if (ctx.config.tunnel) {

--- a/src/lib/processSnapshot.ts
+++ b/src/lib/processSnapshot.ts
@@ -93,7 +93,7 @@ export async function prepareSnapshot(snapshot: Snapshot, ctx: Context): Promise
                     processedOptions.web.browsers = options.web.browsers;
                 }
             }
-        } else if (!options.web && ctx.config.web?.browserViewports) {
+        } else if (ctx.config.web?.browserViewports) {
             processedOptions.web = { browserViewports: ctx.config.web.browserViewports };
         }
 
@@ -581,7 +581,7 @@ export default async function processSnapshot(snapshot: Snapshot, ctx: Context):
                     processedOptions.web.browsers = options.web.browsers;
                 }
             }
-        } else if (!options.web && ctx.config.web?.browserViewports) {
+        } else if (ctx.config.web?.browserViewports) {
             processedOptions.web = { browserViewports: ctx.config.web.browserViewports };
         }
 

--- a/src/lib/processSnapshot.ts
+++ b/src/lib/processSnapshot.ts
@@ -93,6 +93,11 @@ export async function prepareSnapshot(snapshot: Snapshot, ctx: Context): Promise
                     processedOptions.web.browsers = options.web.browsers;
                 }
             }
+
+            // Clear empty web object so global fallback can trigger
+            if (Object.keys(processedOptions.web).length === 0) {
+                delete processedOptions.web;
+            }
         }
 
         if (options.mobile && Object.keys(options.mobile).length) {
@@ -590,6 +595,11 @@ export default async function processSnapshot(snapshot: Snapshot, ctx: Context):
                 if (options.web.browsers && options.web.browsers.length > 0) {
                     processedOptions.web.browsers = options.web.browsers;
                 }
+            }
+
+            // Clear empty web object so global fallback can trigger
+            if (Object.keys(processedOptions.web).length === 0) {
+                delete processedOptions.web;
             }
         }
 

--- a/src/lib/processSnapshot.ts
+++ b/src/lib/processSnapshot.ts
@@ -1,5 +1,5 @@
 import { Snapshot, Context, DiscoveryErrors } from "../types.js";
-import { scrollToBottomAndBackToTop, smoothScrollToBottom, getRenderViewports, getRenderViewportsForOptions, validateCoordinates, resolveCustomCSS, parseCSSFile, validateCSSSelectors, generateCSSInjectionReport } from "./utils.js"
+import { scrollToBottomAndBackToTop, smoothScrollToBottom, getRenderViewports, getRenderViewportsForOptions, validateCoordinates, resolveCustomCSS, parseCSSFile, validateCSSSelectors, generateCSSInjectionReport, transformCustomViewportsToBrowserViewports } from "./utils.js"
 import { chromium, Locator } from "@playwright/test"
 import constants from "./constants.js";
 import { updateLogContext } from '../lib/logger.js'
@@ -78,17 +78,23 @@ export async function prepareSnapshot(snapshot: Snapshot, ctx: Context): Promise
         if (options.web && Object.keys(options.web).length) {
             processedOptions.web = {};
 
-            // Check and process viewports in web
-            if (options.web.viewports && options.web.viewports.length > 0) {
-                processedOptions.web.viewports = options.web.viewports.filter(viewport =>
-                    Array.isArray(viewport) && viewport.length > 0
-                );
-            }
+            if (options.web.customViewports && Array.isArray(options.web.customViewports) && options.web.customViewports.length > 0) {
+                processedOptions.web.browserViewports = transformCustomViewportsToBrowserViewports(options.web.customViewports);
+            } else {
+                // Check and process viewports in web
+                if (options.web.viewports && options.web.viewports.length > 0) {
+                    processedOptions.web.viewports = options.web.viewports.filter(viewport =>
+                        Array.isArray(viewport) && viewport.length > 0
+                    );
+                }
 
-            // Check and process browsers in web
-            if (options.web.browsers && options.web.browsers.length > 0) {
-                processedOptions.web.browsers = options.web.browsers;
+                // Check and process browsers in web
+                if (options.web.browsers && options.web.browsers.length > 0) {
+                    processedOptions.web.browsers = options.web.browsers;
+                }
             }
+        } else if (!options.web && ctx.config.web?.browserViewports) {
+            processedOptions.web = { browserViewports: ctx.config.web.browserViewports };
         }
 
         if (options.mobile && Object.keys(options.mobile).length) {
@@ -560,17 +566,23 @@ export default async function processSnapshot(snapshot: Snapshot, ctx: Context):
         if (options.web && Object.keys(options.web).length) {
             processedOptions.web = {};
 
-            // Check and process viewports in web
-            if (options.web.viewports && options.web.viewports.length > 0) {
-                processedOptions.web.viewports = options.web.viewports.filter(viewport =>
-                    Array.isArray(viewport) && viewport.length > 0
-                );
-            }
+            if (options.web.customViewports && Array.isArray(options.web.customViewports) && options.web.customViewports.length > 0) {
+                processedOptions.web.browserViewports = transformCustomViewportsToBrowserViewports(options.web.customViewports);
+            } else {
+                // Check and process viewports in web
+                if (options.web.viewports && options.web.viewports.length > 0) {
+                    processedOptions.web.viewports = options.web.viewports.filter(viewport =>
+                        Array.isArray(viewport) && viewport.length > 0
+                    );
+                }
 
-            // Check and process browsers in web
-            if (options.web.browsers && options.web.browsers.length > 0) {
-                processedOptions.web.browsers = options.web.browsers;
+                // Check and process browsers in web
+                if (options.web.browsers && options.web.browsers.length > 0) {
+                    processedOptions.web.browsers = options.web.browsers;
+                }
             }
+        } else if (!options.web && ctx.config.web?.browserViewports) {
+            processedOptions.web = { browserViewports: ctx.config.web.browserViewports };
         }
 
         if (options.mobile && Object.keys(options.mobile).length) {

--- a/src/lib/processSnapshot.ts
+++ b/src/lib/processSnapshot.ts
@@ -93,8 +93,6 @@ export async function prepareSnapshot(snapshot: Snapshot, ctx: Context): Promise
                     processedOptions.web.browsers = options.web.browsers;
                 }
             }
-        } else if (ctx.config.web?.browserViewports) {
-            processedOptions.web = { browserViewports: ctx.config.web.browserViewports };
         }
 
         if (options.mobile && Object.keys(options.mobile).length) {
@@ -158,6 +156,11 @@ export async function prepareSnapshot(snapshot: Snapshot, ctx: Context): Promise
         if (options.ignoreType) {
             processedOptions.ignoreType = options.ignoreType;
         }
+    }
+
+    // Global browserViewports fallback — runs when options is empty or has no web override
+    if (!processedOptions.web && ctx.config.web?.browserViewports) {
+        processedOptions.web = { browserViewports: ctx.config.web.browserViewports };
     }
 
     if (ctx.config.tunnel) {
@@ -581,8 +584,6 @@ export default async function processSnapshot(snapshot: Snapshot, ctx: Context):
                     processedOptions.web.browsers = options.web.browsers;
                 }
             }
-        } else if (ctx.config.web?.browserViewports) {
-            processedOptions.web = { browserViewports: ctx.config.web.browserViewports };
         }
 
         if (options.mobile && Object.keys(options.mobile).length) {
@@ -646,6 +647,11 @@ export default async function processSnapshot(snapshot: Snapshot, ctx: Context):
         if (options.ignoreType) {
             processedOptions.ignoreType = options.ignoreType;
         }
+    }
+
+    // Global browserViewports fallback — runs when options is empty or has no web override
+    if (!processedOptions.web && ctx.config.web?.browserViewports) {
+        processedOptions.web = { browserViewports: ctx.config.web.browserViewports };
     }
 
     if (ctx.config.tunnel) {

--- a/src/lib/schemaValidation.ts
+++ b/src/lib/schemaValidation.ts
@@ -54,10 +54,43 @@ const ConfigSchema = {
                     uniqueItems: true,
                     maxItems: 5,
                     errorMessage: "Invalid config; max unique viewports allowed - 5"
+                },
+                customViewports: {
+                    type: "array",
+                    items: {
+                        type: "object",
+                        properties: {
+                            browser: {
+                                type: "string",
+                                enum: [constants.CHROME, constants.FIREFOX, constants.SAFARI, constants.EDGE],
+                                errorMessage: `Invalid config; allowed browsers - ${constants.CHROME}, ${constants.FIREFOX}, ${constants.SAFARI}, ${constants.EDGE}`
+                            },
+                            viewport: {
+                                type: "array",
+                                oneOf: [
+                                    {
+                                        items: [{ type: "number", minimum: 320, maximum: 7680 }],
+                                        minItems: 1,
+                                        maxItems: 1
+                                    },
+                                    {
+                                        items: [
+                                            { type: "number", minimum: 320, maximum: 7680 },
+                                            { type: "number", minimum: 320, maximum: 7680 }
+                                        ],
+                                        minItems: 2,
+                                        maxItems: 2
+                                    }
+                                ],
+                                errorMessage: "Invalid config; customViewports viewport width/height must be >= 320 and <= 7680"
+                            }
+                        },
+                        required: ["browser", "viewport"],
+                        additionalProperties: false
+                    },
+                    errorMessage: "Invalid config; customViewports must be an array of {browser, viewport} objects"
                 }
-            },
-            required: ["browsers", "viewports"],
-            additionalProperties: false
+            }
         },
         mobile: {
             type: "object",
@@ -570,10 +603,30 @@ const SnapshotSchema: JSONSchemaType<Snapshot> = {
                             },
                             uniqueItems: true,
                             errorMessage: "Invalid snapshot options; viewports must be an array of unique arrays."
+                        },
+                        customViewports: {
+                            type: "array",
+                            items: {
+                                type: "object",
+                                properties: {
+                                    browser: {
+                                        type: "string",
+                                        enum: [constants.CHROME, constants.FIREFOX, constants.SAFARI, constants.EDGE],
+                                    },
+                                    viewport: {
+                                        type: "array",
+                                        items: { type: "number", minimum: 1 },
+                                        minItems: 1,
+                                        maxItems: 2,
+                                    }
+                                },
+                                required: ["browser", "viewport"],
+                                additionalProperties: false
+                            },
+                            errorMessage: "Invalid snapshot options; customViewports must be an array of {browser, viewport} objects"
                         }
                     },
-                    required: ["viewports"],
-                    errorMessage: "Invalid snapshot options; web must include viewports property."
+                    errorMessage: "Invalid snapshot options; web must include viewports or customViewports property."
                 },
                 mobile: {
                     type: "object",

--- a/src/lib/schemaValidation.ts
+++ b/src/lib/schemaValidation.ts
@@ -27,11 +27,16 @@ const ConfigSchema = {
                     type: "array",
                     items: { type: "string", enum: [constants.CHROME, constants.FIREFOX, constants.SAFARI, constants.EDGE] },
                     uniqueItems: true,
+                    minItems: 1,
                     maxItems: 4,
-                    errorMessage: `Invalid config; allowed browsers - ${constants.CHROME}, ${constants.FIREFOX}, ${constants.SAFARI}, ${constants.EDGE}`
+                    errorMessage: {
+                        minItems: "Invalid config; browsers must have at least one entry",
+                        _: `Invalid config; allowed browsers - ${constants.CHROME}, ${constants.FIREFOX}, ${constants.SAFARI}, ${constants.EDGE}`
+                    }
                 },
                 viewports: {
                     type: "array",
+                    minItems: 1,
                     items: {
                         type: "array",
                         oneOf: [
@@ -53,10 +58,14 @@ const ConfigSchema = {
                     },
                     uniqueItems: true,
                     maxItems: 5,
-                    errorMessage: "Invalid config; max unique viewports allowed - 5"
+                    errorMessage: {
+                        minItems: "Invalid config; viewports must have at least one entry",
+                        maxItems: "Invalid config; max unique viewports allowed - 5"
+                    }
                 },
                 customViewports: {
                     type: "array",
+                    minItems: 1,
                     items: {
                         type: "object",
                         properties: {
@@ -88,7 +97,10 @@ const ConfigSchema = {
                         required: ["browser", "viewport"],
                         additionalProperties: false
                     },
-                    errorMessage: "Invalid config; customViewports must be an array of {browser, viewport} objects"
+                    errorMessage: {
+                        minItems: "Invalid config; customViewports must have at least one entry",
+                        _: "Invalid config; customViewports must be an array of {browser, viewport} objects"
+                    }
                 }
             }
         },

--- a/src/lib/snapshotQueue.ts
+++ b/src/lib/snapshotQueue.ts
@@ -174,6 +174,8 @@ export default class Queue {
         // Process web configurations if they exist in config
         if (config.web) {
             if (config.web.browserViewports) {
+                // Build customViewports array to preserve per-browser pairing downstream
+                const customViewports: Array<{ browser: string, viewport: [number] | [number, number] }> = [];
                 for (const [browser, viewports] of Object.entries(config.web.browserViewports)) {
                     for (const viewport of viewports as Array<{ width: number, height: number }>) {
                         const width = viewport.width;
@@ -182,22 +184,28 @@ export default class Queue {
 
                         if (!this.variants.includes(variant)) {
                             allVariantsDropped = false;
-                            if (!snapshot.options) snapshot.options = {};
-                            if (!snapshot.options.web) snapshot.options.web = { browsers: [], viewports: [] };
-                            if (!snapshot.options.web.browsers.includes(browser)) {
-                                snapshot.options.web.browsers.push(browser);
+                            if (height > 0) {
+                                customViewports.push({ browser, viewport: [width, height] });
+                            } else {
+                                customViewports.push({ browser, viewport: [width] });
                             }
-                            const viewportExists = snapshot.options.web.viewports.some(existingViewport =>
-                                existingViewport[0] === width &&
-                                (existingViewport.length < 2 || existingViewport[1] === height)
-                            );
-                            if (!viewportExists) {
-                                if (height > 0) {
-                                    snapshot.options.web.viewports.push([width, height]);
-                                } else {
-                                    snapshot.options.web.viewports.push([width]);
-                                }
-                            }
+                        }
+                    }
+                }
+                if (customViewports.length > 0) {
+                    if (!snapshot.options) snapshot.options = {};
+                    snapshot.options.web = { browsers: [], viewports: [], customViewports };
+                    // Also populate browsers/viewports for backward compat
+                    for (const entry of customViewports) {
+                        if (!snapshot.options.web.browsers.includes(entry.browser)) {
+                            snapshot.options.web.browsers.push(entry.browser);
+                        }
+                        const vp = entry.viewport;
+                        const viewportExists = snapshot.options.web.viewports.some(ev =>
+                            ev[0] === vp[0] && (ev.length < 2 || ev[1] === (vp[1] || 0))
+                        );
+                        if (!viewportExists) {
+                            snapshot.options.web.viewports.push(vp);
                         }
                     }
                 }
@@ -272,9 +280,12 @@ export default class Queue {
             snapshot.options = {};
         }
 
-        snapshot.options.web = { browsers: [], viewports: [] };
-
         if (webConfig.customViewports && Array.isArray(webConfig.customViewports) && webConfig.customViewports.length > 0) {
+            // Preserve customViewports so per-browser pairing isn't lost downstream
+            const filteredCustomViewports: Array<{ browser: string, viewport: [number] | [number, number] }> = [];
+            const browsers: string[] = [];
+            const viewports: ([number] | [number, number])[] = [];
+
             for (const entry of webConfig.customViewports) {
                 const width = entry.viewport[0];
                 const height = entry.viewport[1] || 0;
@@ -282,23 +293,25 @@ export default class Queue {
 
                 if (!this.variants.includes(variant)) {
                     allVariantsDropped = false;
-                    if (!snapshot.options.web.browsers.includes(entry.browser)) {
-                        snapshot.options.web.browsers.push(entry.browser);
+                    filteredCustomViewports.push(entry);
+                    if (!browsers.includes(entry.browser)) {
+                        browsers.push(entry.browser);
                     }
-                    const viewportExists = snapshot.options.web.viewports.some(existingViewport =>
-                        existingViewport[0] === width &&
-                        (existingViewport.length < 2 || existingViewport[1] === height)
+                    const viewportExists = viewports.some(ev =>
+                        ev[0] === width && (ev.length < 2 || ev[1] === height)
                     );
                     if (!viewportExists) {
                         if (height > 0) {
-                            snapshot.options.web.viewports.push([width, height]);
+                            viewports.push([width, height]);
                         } else {
-                            snapshot.options.web.viewports.push([width]);
+                            viewports.push([width]);
                         }
                     }
                 }
             }
+            snapshot.options.web = { browsers, viewports, customViewports: filteredCustomViewports };
         } else {
+            snapshot.options.web = { browsers: [], viewports: [] };
             const browsers = webConfig.browsers ?? this.ctx.config.web?.browsers ?? [constants.CHROME, constants.EDGE, constants.FIREFOX, constants.SAFARI];
             const viewports = webConfig.viewports || [];
 

--- a/src/lib/snapshotQueue.ts
+++ b/src/lib/snapshotQueue.ts
@@ -49,16 +49,19 @@ export default class Queue {
     }
 
     private processGenerateVariants(snapshot: Snapshot): void {
+        let hasWebOptions = snapshot.options?.web && Object.keys(snapshot.options.web).length > 0;
+        let hasMobileOptions = snapshot.options?.mobile && Object.keys(snapshot.options.mobile).length > 0;
+
         if (snapshot.options) {
-            if (snapshot.options.web) {
+            if (hasWebOptions) {
                 this.generateWebVariants(snapshot, snapshot.options.web);
             }
-            if (snapshot.options.mobile) {
+            if (hasMobileOptions) {
                 this.generateMobileVariants(snapshot, snapshot.options.mobile);
             }
         }
 
-        if (!snapshot.options || (snapshot.options && !snapshot.options.web && !snapshot.options.mobile)) {
+        if (!snapshot.options || (!hasWebOptions && !hasMobileOptions)) {
             this.generateVariants(snapshot, this.ctx.config);
         }
     }
@@ -142,19 +145,21 @@ export default class Queue {
     private filterExistingVariants(snapshot: Snapshot, config: any): boolean {
 
         let drop = true;
+        let hasWebOptions = snapshot.options?.web && Object.keys(snapshot.options.web).length > 0;
+        let hasMobileOptions = snapshot.options?.mobile && Object.keys(snapshot.options.mobile).length > 0;
 
-        if (snapshot.options && snapshot.options.web) {
+        if (snapshot.options && hasWebOptions) {
             const webDrop = this.filterWebVariants(snapshot, snapshot.options.web);
             if (!webDrop) drop = false;
         }
 
-        if (snapshot.options && snapshot.options.mobile) {
+        if (snapshot.options && hasMobileOptions) {
             const mobileDrop = this.filterMobileVariants(snapshot, snapshot.options.mobile);
             if (!mobileDrop) drop = false;
         }
 
         // Fallback to the global config if neither web nor mobile options are present in snapshot.options
-        if (!snapshot.options || (snapshot.options && !snapshot.options.web && !snapshot.options.mobile)) {
+        if (!snapshot.options || (!hasWebOptions && !hasMobileOptions)) {
             const configDrop = this.filterVariants(snapshot, config);
             if (!configDrop) drop = false;
         }

--- a/src/lib/snapshotQueue.ts
+++ b/src/lib/snapshotQueue.ts
@@ -68,6 +68,16 @@ export default class Queue {
         // Process web configurations if they exist
 
         if (config.web) {
+            if (config.web.browserViewports) {
+                for (const [browser, viewports] of Object.entries(config.web.browserViewports)) {
+                    for (const viewport of viewports as Array<{ width: number, height: number }>) {
+                        const width = viewport.width;
+                        const height = viewport.height || 0;
+                        const variant = `${snapshot.name}_${browser}_viewport[${width}]_viewport[${height}]`;
+                        this.variants.push(variant);
+                    }
+                }
+            } else {
             const browsers = config.web.browsers || [];
             const viewports = config.web.viewports || [];
 
@@ -78,6 +88,7 @@ export default class Queue {
                     const variant = `${snapshot.name}_${browser}_viewport[${width}]_viewport[${height}]`;
                     this.variants.push(variant);
                 }
+            }
             }
         }
 
@@ -95,15 +106,24 @@ export default class Queue {
 
 
     private generateWebVariants(snapshot: Snapshot, webConfig: any): void {
-        const browsers = webConfig.browsers ?? this.ctx.config.web?.browsers ?? [constants.CHROME, constants.EDGE, constants.FIREFOX, constants.SAFARI];
-        const viewports = webConfig.viewports || [];
-
-        for (const browser of browsers) {
-            for (const viewport of viewports) {
-                const width = viewport[0];
-                const height = viewport[1] || 0;  // Use 0 if height is not provided
-                const variant = `${snapshot.name}_${browser}_viewport[${width}]_viewport[${height}]`;
+        if (webConfig.customViewports && Array.isArray(webConfig.customViewports) && webConfig.customViewports.length > 0) {
+            for (const entry of webConfig.customViewports) {
+                const width = entry.viewport[0];
+                const height = entry.viewport[1] || 0;
+                const variant = `${snapshot.name}_${entry.browser}_viewport[${width}]_viewport[${height}]`;
                 this.variants.push(variant);
+            }
+        } else {
+            const browsers = webConfig.browsers ?? this.ctx.config.web?.browsers ?? [constants.CHROME, constants.EDGE, constants.FIREFOX, constants.SAFARI];
+            const viewports = webConfig.viewports || [];
+
+            for (const browser of browsers) {
+                for (const viewport of viewports) {
+                    const width = viewport[0];
+                    const height = viewport[1] || 0;  // Use 0 if height is not provided
+                    const variant = `${snapshot.name}_${browser}_viewport[${width}]_viewport[${height}]`;
+                    this.variants.push(variant);
+                }
             }
         }
     }
@@ -148,6 +168,35 @@ export default class Queue {
 
         // Process web configurations if they exist in config
         if (config.web) {
+            if (config.web.browserViewports) {
+                for (const [browser, viewports] of Object.entries(config.web.browserViewports)) {
+                    for (const viewport of viewports as Array<{ width: number, height: number }>) {
+                        const width = viewport.width;
+                        const height = viewport.height || 0;
+                        const variant = `${snapshot.name}_${browser}_viewport[${width}]_viewport[${height}]`;
+
+                        if (!this.variants.includes(variant)) {
+                            allVariantsDropped = false;
+                            if (!snapshot.options) snapshot.options = {};
+                            if (!snapshot.options.web) snapshot.options.web = { browsers: [], viewports: [] };
+                            if (!snapshot.options.web.browsers.includes(browser)) {
+                                snapshot.options.web.browsers.push(browser);
+                            }
+                            const viewportExists = snapshot.options.web.viewports.some(existingViewport =>
+                                existingViewport[0] === width &&
+                                (existingViewport.length < 2 || existingViewport[1] === height)
+                            );
+                            if (!viewportExists) {
+                                if (height > 0) {
+                                    snapshot.options.web.viewports.push([width, height]);
+                                } else {
+                                    snapshot.options.web.viewports.push([width]);
+                                }
+                            }
+                        }
+                    }
+                }
+            } else {
             const browsers = config.web.browsers || [];
             const viewports = config.web.viewports || [];
 
@@ -182,6 +231,7 @@ export default class Queue {
                     }
                 }
             }
+            }
         }
 
         // Process mobile configurations if they exist in config
@@ -211,8 +261,6 @@ export default class Queue {
     }
 
     private filterWebVariants(snapshot: Snapshot, webConfig: any): boolean {
-        const browsers = webConfig.browsers ?? this.ctx.config.web?.browsers ?? [constants.CHROME, constants.EDGE, constants.FIREFOX, constants.SAFARI];
-        const viewports = webConfig.viewports || [];
         let allVariantsDropped = true;
 
         if (!snapshot.options) {
@@ -221,18 +269,17 @@ export default class Queue {
 
         snapshot.options.web = { browsers: [], viewports: [] };
 
-        for (const browser of browsers) {
-            for (const viewport of viewports) {
-                const width = viewport[0];
-                const height = viewport[1] || 0;
-                const variant = `${snapshot.name}_${browser}_viewport[${width}]_viewport[${height}]`;
+        if (webConfig.customViewports && Array.isArray(webConfig.customViewports) && webConfig.customViewports.length > 0) {
+            for (const entry of webConfig.customViewports) {
+                const width = entry.viewport[0];
+                const height = entry.viewport[1] || 0;
+                const variant = `${snapshot.name}_${entry.browser}_viewport[${width}]_viewport[${height}]`;
 
                 if (!this.variants.includes(variant)) {
-                    allVariantsDropped = false; // Found a variant that needs processing
-                    if (!snapshot.options.web.browsers.includes(browser)) {
-                        snapshot.options.web.browsers.push(browser);
+                    allVariantsDropped = false;
+                    if (!snapshot.options.web.browsers.includes(entry.browser)) {
+                        snapshot.options.web.browsers.push(entry.browser);
                     }
-                    // Only add unique viewports to avoid duplicates
                     const viewportExists = snapshot.options.web.viewports.some(existingViewport =>
                         existingViewport[0] === width &&
                         (existingViewport.length < 2 || existingViewport[1] === height)
@@ -242,6 +289,36 @@ export default class Queue {
                             snapshot.options.web.viewports.push([width, height]);
                         } else {
                             snapshot.options.web.viewports.push([width]);
+                        }
+                    }
+                }
+            }
+        } else {
+            const browsers = webConfig.browsers ?? this.ctx.config.web?.browsers ?? [constants.CHROME, constants.EDGE, constants.FIREFOX, constants.SAFARI];
+            const viewports = webConfig.viewports || [];
+
+            for (const browser of browsers) {
+                for (const viewport of viewports) {
+                    const width = viewport[0];
+                    const height = viewport[1] || 0;
+                    const variant = `${snapshot.name}_${browser}_viewport[${width}]_viewport[${height}]`;
+
+                    if (!this.variants.includes(variant)) {
+                        allVariantsDropped = false; // Found a variant that needs processing
+                        if (!snapshot.options.web.browsers.includes(browser)) {
+                            snapshot.options.web.browsers.push(browser);
+                        }
+                        // Only add unique viewports to avoid duplicates
+                        const viewportExists = snapshot.options.web.viewports.some(existingViewport =>
+                            existingViewport[0] === width &&
+                            (existingViewport.length < 2 || existingViewport[1] === height)
+                        );
+                        if (!viewportExists) {
+                            if (height > 0) {
+                                snapshot.options.web.viewports.push([width, height]);
+                            } else {
+                                snapshot.options.web.viewports.push([width]);
+                            }
                         }
                     }
                 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -569,9 +569,15 @@ export function calculateVariantCount(config: any): number {
 
     // Calculate web variants
     if (config.web) {
-        const browsers = config.web.browsers || [];
-        const viewports = config.web.viewports || [];
-        variantCount += browsers.length * viewports.length;
+        if (config.web.browserViewports) {
+            for (const viewports of Object.values(config.web.browserViewports)) {
+                variantCount += (viewports as Array<any>).length;
+            }
+        } else {
+            const browsers = config.web.browsers || [];
+            const viewports = config.web.viewports || [];
+            variantCount += browsers.length * viewports.length;
+        }
     }
 
     // Calculate mobile variants
@@ -583,21 +589,20 @@ export function calculateVariantCount(config: any): number {
     return variantCount;
 }
 
-/**
- * Calculate the number of variants for a snapshot based on snapshot-specific options
- * @param snapshot - The snapshot object with options
- * @param globalConfig - The global configuration object (fallback)
- * @returns The total number of variants that would be generated
- */
 export function calculateVariantCountFromSnapshot(snapshot: any, globalConfig?: any): number {
     let variantCount = 0;
-    
 
     // Check snapshot-specific web options
     if (snapshot.options?.web) {
-        const browsers = snapshot.options.web.browsers || [];
-        const viewports = snapshot.options.web.viewports || [];
-        variantCount += browsers.length * viewports.length;
+        if (snapshot.options.web.browserViewports) {
+            for (const viewports of Object.values(snapshot.options.web.browserViewports)) {
+                variantCount += (viewports as Array<any>).length;
+            }
+        } else {
+            const browsers = snapshot.options.web.browsers || [];
+            const viewports = snapshot.options.web.viewports || [];
+            variantCount += browsers.length * viewports.length;
+        }
     }
 
     // Check snapshot-specific mobile options

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -139,13 +139,31 @@ export function getWebRenderViewports(ctx: Context): Array<Record<string, any>> 
     let webRenderViewports: Array<Record<string, any>> = [];
 
     if (ctx.config.web) {
-        for (const viewport of ctx.config.web.viewports) {
-            webRenderViewports.push({
-                viewport,
-                viewportString: `${viewport.width}${viewport.height ? 'x' + viewport.height : ''}`,
-                fullPage: viewport.height ? false : true,
-                device: false
-            })
+        if (ctx.config.web.browserViewports) {
+            const seen = new Set<string>();
+            for (const viewports of Object.values(ctx.config.web.browserViewports)) {
+                for (const viewport of viewports as Array<{ width: number, height: number }>) {
+                    const key = `${viewport.width}x${viewport.height}`;
+                    if (!seen.has(key)) {
+                        seen.add(key);
+                        webRenderViewports.push({
+                            viewport,
+                            viewportString: `${viewport.width}${viewport.height ? 'x' + viewport.height : ''}`,
+                            fullPage: viewport.height ? false : true,
+                            device: false
+                        });
+                    }
+                }
+            }
+        } else {
+            for (const viewport of ctx.config.web.viewports) {
+                webRenderViewports.push({
+                    viewport,
+                    viewportString: `${viewport.width}${viewport.height ? 'x'+viewport.height : ''}`,
+                    fullPage: viewport.height ? false : true,
+                    device: false
+                })
+            }
         }
     }
 
@@ -155,7 +173,24 @@ export function getWebRenderViewports(ctx: Context): Array<Record<string, any>> 
 export function getWebRenderViewportsForOptions(options: any): Array<Record<string, any>> {
     let webRenderViewports: Array<Record<string, any>> = [];
 
-    if (options.web && Array.isArray(options.web.viewports)) {
+    if (options.web && Array.isArray(options.web.customViewports) && options.web.customViewports.length > 0) {
+        const browserViewports = transformCustomViewportsToBrowserViewports(options.web.customViewports);
+        const seen = new Set<string>();
+        for (const viewports of Object.values(browserViewports)) {
+            for (const vp of viewports as Array<{ width: number, height: number }>) {
+                const key = `${vp.width}x${vp.height}`;
+                if (!seen.has(key)) {
+                    seen.add(key);
+                    webRenderViewports.push({
+                        viewport: vp,
+                        viewportString: `${vp.width}${vp.height ? 'x' + vp.height : ''}`,
+                        fullPage: vp.height ? false : true,
+                        device: false
+                    });
+                }
+            }
+        }
+    } else if (options.web && Array.isArray(options.web.viewports)) {
         for (const viewport of options.web.viewports) {
             if (Array.isArray(viewport) && viewport.length > 0) {
                 let viewportObj: { width: number; height?: number } = {
@@ -168,7 +203,7 @@ export function getWebRenderViewportsForOptions(options: any): Array<Record<stri
 
                 webRenderViewports.push({
                     viewport: viewportObj,
-                    viewportString: `${viewport[0]}${viewport[1] ? 'x' + viewport[1] : ''}`,
+                    viewportString: `${viewport[0]}${viewport[1] ? 'x'+viewport[1] : ''}`,
                     fullPage: viewport.length === 1,
                     device: false
                 });
@@ -177,6 +212,25 @@ export function getWebRenderViewportsForOptions(options: any): Array<Record<stri
     }
 
     return webRenderViewports;
+}
+
+export function transformCustomViewportsToBrowserViewports(
+    customViewports: Array<{ browser: string, viewport: [number] | [number, number] }>
+): Record<string, Array<{ width: number, height: number }>> {
+    const browserViewports: Record<string, Array<{ width: number, height: number }>> = {};
+    for (const entry of customViewports) {
+        if (!browserViewports[entry.browser]) {
+            browserViewports[entry.browser] = [];
+        }
+        const vp = { width: entry.viewport[0], height: entry.viewport[1] || 0 };
+        const exists = browserViewports[entry.browser].some(
+            existing => existing.width === vp.width && existing.height === vp.height
+        );
+        if (!exists) {
+            browserViewports[entry.browser].push(vp);
+        }
+    }
+    return browserViewports;
 }
 
 export function getMobileRenderViewports(ctx: Context): Record<string, any> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -173,7 +173,8 @@ export interface Snapshot {
         },
         web?: {
             browsers?: string[],
-            viewports: ([number] | [number, number])[]
+            viewports: ([number] | [number, number])[],
+            customViewports?: Array<{ browser: string, viewport: [number] | [number, number] }>
         },
         mobile?: {
             devices: string[],
@@ -224,9 +225,15 @@ export interface Build {
     checkPendingRequests: boolean;
 }
 
+export interface CustomViewportEntry {
+    browser: string;
+    viewport: { width: number, height?: number };
+}
+
 export interface WebConfig {
     browsers: Array<string>;
     viewports: Array<{ width: number, height: number }>;
+    browserViewports?: Record<string, Array<{ width: number, height: number }>>;
 }
 
 export interface MobileConfig {


### PR DESCRIPTION
## Summary
- Add `CustomViewportEntry` type and `browserViewports` field to `WebConfig`
- Add `customViewports` JSON schema validation for both global config and per-snapshot options
- Transform `customViewports` → `browserViewports` in context initialization (`ctx.ts`)
- Add shared `transformCustomViewportsToBrowserViewports()` helper in `utils.ts`
- Update `getWebRenderViewports`, `getWebRenderViewportsForOptions` with `browserViewports`/`customViewports` branches
- Update `processSnapshot` (both remote and local discovery paths) to handle `customViewports` → `browserViewports` transform
- Update `generateVariants`, `generateWebVariants`, `filterVariants`, `filterWebVariants` in snapshot queue

## Context
Adds per-browser custom viewports for SmartUI SDK exec flow. Currently `browsers × viewports` is a cartesian product. This adds `customViewports` config that lets users define explicit browser+viewport pairs. When present, `customViewports` takes priority over `browsers`+`viewports`.

Example config:
```json
{
  "web": {
    "customViewports": [
      { "browser": "chrome", "viewport": [1440] },
      { "browser": "chrome", "viewport": [1080, 720] },
      { "browser": "firefox", "viewport": [1440] }
    ]
  }
}
```

Fully backward compatible — existing configs without `customViewports` are unchanged.

## Test plan
- [x] TC-001: Valid customViewports with 3 browser+viewport pairs — build created OK
- [x] TC-002: customViewports + browsers/viewports both present — customViewports wins
- [x] TC-004: customViewports + mobile combo (iPhone 14 + Galaxy S24) — 5 variants OK
- [x] TC-005: Backward compat with existing browsers+viewports config — cartesian unchanged
- [x] TC-006: Same-width-different-height viewports — no collision
- [x] TC-012: All 4 browsers with customViewports — all rendered
- [x] TC-013: Single browser, multiple viewports — only that browser rendered
- [x] TC-026: Single entry customViewports — single screenshot
- [x] All tests pass with both local and remote discovery (21 builds total)
- [x] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)