### PR TITLE
Session capabilities resolution and caching

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lambdatest/smartui-cli",
-  "version": "4.1.56-beta.1",
+  "version": "4.1.56-beta.2",
   "description": "A command line interface (CLI) to run SmartUI tests on LambdaTest",
   "files": [
     "dist/**/*"

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -368,11 +368,29 @@ export default async (ctx: Context): Promise<FastifyInstance<Server, IncomingMes
 			let resolvedBuildId = '';
 			let projectToken = '';
 
-			if (sessionId && ctx.sessionCapabilitiesMap?.has(sessionId)) {
-				const cachedCapabilities = ctx.sessionCapabilitiesMap.get(sessionId);
-				resolvedBuildId = cachedCapabilities?.buildId || '';
-				projectToken = cachedCapabilities?.projectToken || '';
-				ctx.log.debug(`Resolved from sessionCapabilitiesMap for sessionId ${sessionId}: buildId=${resolvedBuildId}, projectToken=${projectToken ? 'present' : 'missing'}`);
+			if (sessionId) {
+				if (ctx.sessionCapabilitiesMap?.has(sessionId)) {
+					// Use cached capabilities if available
+					const cachedCapabilities = ctx.sessionCapabilitiesMap.get(sessionId);
+					resolvedBuildId = cachedCapabilities?.buildId || '';
+					projectToken = cachedCapabilities?.projectToken || '';
+					ctx.log.debug(`Resolved from sessionCapabilitiesMap for sessionId ${sessionId}: buildId=${resolvedBuildId}, projectToken=${projectToken ? 'present' : 'missing'}`);
+				} else {
+					// If not cached, fetch from API and cache it (same as snapshot flow)
+					try {
+						const fetchedCapabilitiesResp = await ctx.client.getSmartUICapabilities(sessionId, ctx.config, ctx.git, ctx.log, ctx.isStartExec, ctx.options.baselineBuild);
+						resolvedBuildId = fetchedCapabilitiesResp?.buildId || '';
+						projectToken = fetchedCapabilitiesResp?.projectToken || '';
+						ctx.log.debug(`Fetched caps for sessionId: ${sessionId} are ${JSON.stringify(fetchedCapabilitiesResp)}`);
+						if (resolvedBuildId) {
+							ctx.sessionCapabilitiesMap.set(sessionId, fetchedCapabilitiesResp);
+						} else if (fetchedCapabilitiesResp && fetchedCapabilitiesResp?.sessionId) {
+							ctx.sessionCapabilitiesMap.set(sessionId, fetchedCapabilitiesResp);
+						}
+					} catch (error: any) {
+						ctx.log.debug(`Failed to fetch capabilities for sessionId ${sessionId}: ${error.message}`);
+					}
+				}
 			}
 			// Skip automation buildIds (short IDs) and fall back to ctx.build.id
 			if ((!resolvedBuildId || resolvedBuildId.length <= 30) && ctx.build && ctx.build.id) {

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -388,7 +388,7 @@ export default async (ctx: Context): Promise<FastifyInstance<Server, IncomingMes
 							ctx.sessionCapabilitiesMap.set(sessionId, fetchedCapabilitiesResp);
 						}
 					} catch (error: any) {
-						ctx.log.debug(`Failed to fetch capabilities for sessionId ${sessionId}: ${error.message}`);
+						ctx.log.debug(`Failed to fetch capabilities for sessionId ${sessionId}: ${JSON.stringify(error)}`);
 					}
 				}
 			}


### PR DESCRIPTION
This pull request introduces improvements to how session capabilities are resolved and cached in the `src/lib/server.ts` file, along with a minor version bump in the `package.json`. The main enhancement ensures that if session capabilities are not already cached, they are fetched from the API and then stored for future use, improving reliability and consistency across flows.

Session capabilities resolution and caching:

* Enhanced the logic in `src/lib/server.ts` to fetch session capabilities from the API if they are not already cached, and then cache them for subsequent requests. This ensures consistent handling across different flows and reduces redundant API calls.

Version update:

* Updated the package version in `package.json` from `4.1.56-beta.1` to `4.1.56-beta.2`.