### PR TITLE
TE-2129: add customViewports support with per-browser viewport config

### DIFF
--- a/src/commander/capture.ts
+++ b/src/commander/capture.ts
@@ -31,6 +31,11 @@ command
         }
         let ctx: Context = ctxInit(command.optsWithGlobals());
         ctx.isSnapshotCaptured = true
+
+        if (ctx.config.web?.browserViewports) {
+            ctx.log.error('customViewports is not supported for the capture command. Use browsers and viewports instead.');
+            process.exit(1);
+        }
         
         if (!fs.existsSync(file)) {
             ctx.log.error(`Web Static Config file ${file} not found.`);

--- a/src/commander/capture.ts
+++ b/src/commander/capture.ts
@@ -29,13 +29,10 @@ command
             console.log(`Error: The '--buildName' option cannot be an empty string.`);
             process.exit(1);
         }
-        let ctx: Context = ctxInit(command.optsWithGlobals());
+        let opts = command.optsWithGlobals();
+        opts.commandType = 'capture';
+        let ctx: Context = ctxInit(opts);
         ctx.isSnapshotCaptured = true
-
-        if (ctx.config.web?.browserViewports) {
-            ctx.log.error('customViewports is not supported for the capture command. Use browsers and viewports instead.');
-            process.exit(1);
-        }
         
         if (!fs.existsSync(file)) {
             ctx.log.error(`Web Static Config file ${file} not found.`);

--- a/src/commander/capture.ts
+++ b/src/commander/capture.ts
@@ -9,6 +9,7 @@ import createBuild from '../tasks/createBuild.js'
 import captureScreenshots from '../tasks/captureScreenshots.js'
 import finalizeBuild from '../tasks/finalizeBuild.js'
 import { validateWebStaticConfig } from '../lib/schemaValidation.js'
+import constants from '../lib/constants.js'
 
 const command = new Command();
 
@@ -30,7 +31,7 @@ command
             process.exit(1);
         }
         let opts = command.optsWithGlobals();
-        opts.commandType = 'capture';
+        opts.commandType = constants.COMMAND_TYPE_CAPTURE;
         let ctx: Context = ctxInit(opts);
         ctx.isSnapshotCaptured = true
         

--- a/src/commander/exec.ts
+++ b/src/commander/exec.ts
@@ -31,7 +31,9 @@ command
             console.log(`Error: The '--buildName' option cannot be an empty string.`);
             process.exit(1);
         }
-        let ctx: Context = ctxInit(command.optsWithGlobals());
+        let opts = command.optsWithGlobals();
+        opts.commandType = 'exec';
+        let ctx: Context = ctxInit(opts);
 
         if (!which.sync(execCommand[0], { nothrow: true })) {
             ctx.log.error(`Error: Command not found "${execCommand[0]}"`);

--- a/src/commander/exec.ts
+++ b/src/commander/exec.ts
@@ -6,6 +6,7 @@ import startServer from '../tasks/startServer.js'
 import authExec from '../tasks/authExec.js'
 import ctxInit from '../lib/ctx.js'
 import commandOptionsInit from '../lib/execCommandOptions.js'
+import constants from '../lib/constants.js'
 import getGitInfo from '../tasks/getGitInfo.js'
 import createBuildExec from '../tasks/createBuildExec.js'
 import exec from '../tasks/exec.js'
@@ -32,7 +33,7 @@ command
             process.exit(1);
         }
         let opts = command.optsWithGlobals();
-        opts.commandType = 'exec';
+        opts.commandType = constants.COMMAND_TYPE_EXEC;
         let ctx: Context = ctxInit(opts);
 
         if (!which.sync(execCommand[0], { nothrow: true })) {

--- a/src/commander/mergeBranch.ts
+++ b/src/commander/mergeBranch.ts
@@ -16,7 +16,9 @@ command
     .requiredOption('--target <string>', 'Target branch to merge into')
     .action(async function(this: Command, options: { source: string, target: string }) {
         const { source, target } = options;
-        let ctx: Context = ctxInit(command.optsWithGlobals());
+        let opts = command.optsWithGlobals();
+        opts.commandType = 'merge';
+        let ctx: Context = ctxInit(opts);
 
         if (!source || source.trim() === '') {
             ctx.log.error('Error: The --source option cannot be empty.');

--- a/src/commander/mergeBranch.ts
+++ b/src/commander/mergeBranch.ts
@@ -6,6 +6,7 @@ import ctxInit from '../lib/ctx.js';
 import fetchBranchInfo from '../tasks/fetchBranchInfo.js'
 import mergeBuilds from '../tasks/mergeBuilds.js'
 import getGitInfo from '../tasks/getGitInfo.js'
+import constants from '../lib/constants.js'
 
 const command = new Command();
 
@@ -17,7 +18,7 @@ command
     .action(async function(this: Command, options: { source: string, target: string }) {
         const { source, target } = options;
         let opts = command.optsWithGlobals();
-        opts.commandType = 'merge';
+        opts.commandType = constants.COMMAND_TYPE_MERGE;
         let ctx: Context = ctxInit(opts);
 
         if (!source || source.trim() === '') {

--- a/src/commander/mergeBuild.ts
+++ b/src/commander/mergeBuild.ts
@@ -6,6 +6,7 @@ import ctxInit from '../lib/ctx.js';
 import fetchBuildInfo from '../tasks/fetchBuildInfo.js'
 import mergeBuilds from '../tasks/mergeBuilds.js'
 import getGitInfo from '../tasks/getGitInfo.js'
+import constants from '../lib/constants.js'
 
 const command = new Command();
 
@@ -17,7 +18,7 @@ command
     .action(async function(this: Command, options: { source: string, target: string }) {
         const { source, target } = options;
         let opts = command.optsWithGlobals();
-        opts.commandType = 'merge';
+        opts.commandType = constants.COMMAND_TYPE_MERGE;
         let ctx: Context = ctxInit(opts);
 
         if (!source || source.trim() === '') {

--- a/src/commander/mergeBuild.ts
+++ b/src/commander/mergeBuild.ts
@@ -16,7 +16,9 @@ command
     .requiredOption('--target <string>', 'Target build to merge into')
     .action(async function(this: Command, options: { source: string, target: string }) {
         const { source, target } = options;
-        let ctx: Context = ctxInit(command.optsWithGlobals());
+        let opts = command.optsWithGlobals();
+        opts.commandType = 'merge';
+        let ctx: Context = ctxInit(opts);
 
         if (!source || source.trim() === '') {
             ctx.log.error('Error: The --source option cannot be empty.');

--- a/src/commander/server.ts
+++ b/src/commander/server.ts
@@ -9,6 +9,7 @@ import createBuildExec from '../tasks/createBuildExec.js';
 import snapshotQueue from '../lib/snapshotQueue.js';
 import { startPolling, startPingPolling } from '../lib/utils.js';
 import startTunnel from '../tasks/startTunnel.js'
+import constants from '../lib/constants.js'
 
 const command = new Command();
 
@@ -25,7 +26,7 @@ command
             process.exit(1);
         }
         let opts = command.optsWithGlobals();
-        opts.commandType = 'exec-start';
+        opts.commandType = constants.COMMAND_TYPE_EXEC_START;
         let ctx: Context = ctxInit(opts);
         ctx.snapshotQueue = new snapshotQueue(ctx);
         ctx.totalSnapshots = 0

--- a/src/commander/server.ts
+++ b/src/commander/server.ts
@@ -24,7 +24,9 @@ command
             console.log(`Error: The '--buildName' option cannot be an empty string.`);
             process.exit(1);
         }
-        let ctx: Context = ctxInit(command.optsWithGlobals());
+        let opts = command.optsWithGlobals();
+        opts.commandType = 'exec-start';
+        let ctx: Context = ctxInit(opts);
         ctx.snapshotQueue = new snapshotQueue(ctx);
         ctx.totalSnapshots = 0
         ctx.isStartExec = true

--- a/src/commander/upload.ts
+++ b/src/commander/upload.ts
@@ -35,13 +35,10 @@ command
             console.log(`Error: The '--buildName' option cannot be an empty string.`);
             process.exit(1);
         }
-        let ctx: Context = ctxInit(command.optsWithGlobals());
+        let opts = command.optsWithGlobals();
+        opts.commandType = 'upload';
+        let ctx: Context = ctxInit(opts);
         ctx.isSnapshotCaptured = true
-
-        if (ctx.config.web?.browserViewports) {
-            ctx.log.error('customViewports is not supported for the upload command. Use browsers and viewports instead.');
-            process.exit(1);
-        }
 
         if (!fs.existsSync(directory)) {
             console.log(`Error: The provided directory ${directory} not found.`);

--- a/src/commander/upload.ts
+++ b/src/commander/upload.ts
@@ -38,6 +38,11 @@ command
         let ctx: Context = ctxInit(command.optsWithGlobals());
         ctx.isSnapshotCaptured = true
 
+        if (ctx.config.web?.browserViewports) {
+            ctx.log.error('customViewports is not supported for the upload command. Use browsers and viewports instead.');
+            process.exit(1);
+        }
+
         if (!fs.existsSync(directory)) {
             console.log(`Error: The provided directory ${directory} not found.`);
             return;

--- a/src/commander/upload.ts
+++ b/src/commander/upload.ts
@@ -36,7 +36,7 @@ command
             process.exit(1);
         }
         let opts = command.optsWithGlobals();
-        opts.commandType = 'upload';
+        opts.commandType = constants.COMMAND_TYPE_UPLOAD;
         let ctx: Context = ctxInit(opts);
         ctx.isSnapshotCaptured = true
 

--- a/src/commander/uploadFigma.ts
+++ b/src/commander/uploadFigma.ts
@@ -26,7 +26,9 @@ uploadFigma
     .option('--markBaseline', 'Mark the uploaded images as baseline')
     .option('--buildName <buildName>', 'Name of the build')
     .action(async function (file, _, command) {
-        let ctx: Context = ctxInit(command.optsWithGlobals());
+        let opts = command.optsWithGlobals();
+        opts.commandType = 'upload-figma';
+        let ctx: Context = ctxInit(opts);
         ctx.isSnapshotCaptured = true;
 
         if (!fs.existsSync(file)) {
@@ -77,7 +79,9 @@ uploadWebFigmaCommand
     .option('--buildName <buildName>', 'Name of the build')
     .option('--fetch-results [filename]', 'Fetch results and optionally specify an output file, e.g., <filename>.json')
     .action(async function (file, _, command) {
-        let ctx: Context = ctxInit(command.optsWithGlobals());
+        let opts = command.optsWithGlobals();
+        opts.commandType = 'upload-figma';
+        let ctx: Context = ctxInit(opts);
 
         if (!fs.existsSync(file)) {
             console.log(`Error: figma-web config file ${file} not found.`);
@@ -144,7 +148,9 @@ uploadWebFigmaCommand
     .option('--buildName <buildName>', 'Name of the build')
     .option('--fetch-results [filename]', 'Fetch results and optionally specify an output file, e.g., <filename>.json')
     .action(async function (file, _, command) {
-        let ctx: Context = ctxInit(command.optsWithGlobals());
+        let opts = command.optsWithGlobals();
+        opts.commandType = 'upload-figma';
+        let ctx: Context = ctxInit(opts);
 
         if (!fs.existsSync(file)) {
             console.log(`Error: figma-app config file ${file} not found.`);

--- a/src/commander/uploadFigma.ts
+++ b/src/commander/uploadFigma.ts
@@ -12,6 +12,7 @@ import uploadWebFigma from '../tasks/uploadWebFigma.js'
 import uploadAppFigma from '../tasks/uploadAppFigma.js'     
 import { verifyFigmaWebConfig } from '../lib/config.js'
 import chalk from 'chalk';
+import constants from '../lib/constants.js';
 
 
 const uploadFigma = new Command();
@@ -27,7 +28,7 @@ uploadFigma
     .option('--buildName <buildName>', 'Name of the build')
     .action(async function (file, _, command) {
         let opts = command.optsWithGlobals();
-        opts.commandType = 'upload-figma';
+        opts.commandType = constants.COMMAND_TYPE_UPLOAD_FIGMA;
         let ctx: Context = ctxInit(opts);
         ctx.isSnapshotCaptured = true;
 
@@ -80,7 +81,7 @@ uploadWebFigmaCommand
     .option('--fetch-results [filename]', 'Fetch results and optionally specify an output file, e.g., <filename>.json')
     .action(async function (file, _, command) {
         let opts = command.optsWithGlobals();
-        opts.commandType = 'upload-figma';
+        opts.commandType = constants.COMMAND_TYPE_UPLOAD_FIGMA;
         let ctx: Context = ctxInit(opts);
 
         if (!fs.existsSync(file)) {
@@ -149,7 +150,7 @@ uploadWebFigmaCommand
     .option('--fetch-results [filename]', 'Fetch results and optionally specify an output file, e.g., <filename>.json')
     .action(async function (file, _, command) {
         let opts = command.optsWithGlobals();
-        opts.commandType = 'upload-figma';
+        opts.commandType = constants.COMMAND_TYPE_UPLOAD_FIGMA;
         let ctx: Context = ctxInit(opts);
 
         if (!fs.existsSync(file)) {

--- a/src/commander/uploadPdf.ts
+++ b/src/commander/uploadPdf.ts
@@ -22,7 +22,9 @@ command
             console.log(`Error: The '--buildName' option cannot be an empty string.`);
             process.exit(1);
         }
-        let ctx: Context = ctxInit(command.optsWithGlobals());
+        let opts = command.optsWithGlobals();
+        opts.commandType = 'upload-pdf';
+        let ctx: Context = ctxInit(opts);
 
         if (!fs.existsSync(directory)) {
             console.log(`Error: The provided directory ${directory} not found.`);

--- a/src/commander/uploadPdf.ts
+++ b/src/commander/uploadPdf.ts
@@ -6,6 +6,7 @@ import fs from 'fs';
 import auth from '../tasks/auth.js';
 import uploadPdfs from '../tasks/uploadPdfs.js';
 import {startPdfPolling} from "../lib/utils.js";
+import constants from '../lib/constants.js';
 const command = new Command();
 
 command
@@ -23,7 +24,7 @@ command
             process.exit(1);
         }
         let opts = command.optsWithGlobals();
-        opts.commandType = 'upload-pdf';
+        opts.commandType = constants.COMMAND_TYPE_UPLOAD_PDF;
         let ctx: Context = ctxInit(opts);
 
         if (!fs.existsSync(directory)) {

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -140,6 +140,16 @@ export default {
     FILE_EXTENSION_ZIP: '.zip',
     FILE_EXTENSION_GIFS: 'gif',
 
+    // command types
+    COMMAND_TYPE_EXEC: 'exec',
+    COMMAND_TYPE_EXEC_START: 'exec-start',
+    COMMAND_TYPE_CAPTURE: 'capture',
+    COMMAND_TYPE_UPLOAD: 'upload',
+    COMMAND_TYPE_UPLOAD_FIGMA: 'upload-figma',
+    COMMAND_TYPE_UPLOAD_PDF: 'upload-pdf',
+    COMMAND_TYPE_MERGE: 'merge',
+    ALLOWED_CUSTOM_VIEWPORT_COMMANDS: ['exec', 'exec-start'],
+
     // Default scrollTime
     DEFAULT_SCROLL_TIME: 8,
 

--- a/src/lib/ctx.ts
+++ b/src/lib/ctx.ts
@@ -101,8 +101,7 @@ export default (options: Record<string, string>): Context => {
             // process.env.LT_ACCESS_KEY = options.accessKey
         }
         // Block customViewports for non-exec commands
-        const allowedCustomViewportCommands = ['exec', 'exec-start'];
-        if (config.web?.customViewports && !allowedCustomViewportCommands.includes(options.commandType)) {
+        if (config.web?.customViewports && !constants.ALLOWED_CUSTOM_VIEWPORT_COMMANDS.includes(options.commandType)) {
             throw new Error('customViewports is only supported for the exec command. Use browsers and viewports instead.');
         }
     } catch (error: any) {

--- a/src/lib/ctx.ts
+++ b/src/lib/ctx.ts
@@ -100,6 +100,11 @@ export default (options: Record<string, string>): Context => {
             // process.env.LT_USERNAME = options.userName
             // process.env.LT_ACCESS_KEY = options.accessKey
         }
+        // Block customViewports for non-exec commands
+        const allowedCustomViewportCommands = ['exec', 'exec-start'];
+        if (config.web?.customViewports && !allowedCustomViewportCommands.includes(options.commandType)) {
+            throw new Error('customViewports is only supported for the exec command. Use browsers and viewports instead.');
+        }
     } catch (error: any) {
         console.log(`[smartui] Error: ${error.message}`);
         process.exit(1);


### PR DESCRIPTION
## Summary
- Adds `customViewports` support for per-browser viewport pairing in exec/SDK flow
- Centralizes `customViewports` blocking in `ctx.ts` — non-exec commands (`capture`, `upload`, `upload-figma`, `upload-pdf`, `merge`) fail fast with a clear error message
- Passes `commandType` from each commander file to `ctxInit()` for gating logic

## Test plan
- [ ] `npx smartui exec` with `customViewports` config works as before
- [ ] `npx smartui capture` with `customViewports` config shows error: "customViewports is only supported for the exec command"
- [ ] `npx smartui upload` with `customViewports` config shows the same error
- [ ] `npm run build` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)