### PR TITLE
Stage to Prod: iPad (9th generation) device config

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lambdatest/smartui-cli",
-  "version": "4.1.58",
+  "version": "4.1.59",
   "description": "A command line interface (CLI) to run SmartUI tests on LambdaTest",
   "files": [
     "dist/**/*"

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -290,6 +290,7 @@ export default {
         'iPad 10.2 (2019)': { os: 'ios', viewport: { width: 810, height: 1080 } },
         'iPad 10.2 (2020)': { os: 'ios', viewport: { width: 834, height: 1194 } },
         'iPad 10.2 (2021)': { os: 'ios', viewport: { width: 810, height: 1080 } },
+        'iPad (9th generation)': { os: 'ios', viewport: { width: 810, height: 1080 } },
         'iPad 9.7 (2017)': { os: 'ios', viewport: { width: 768, height: 1024 } },
         'iPad Air (2019)': { os: 'ios', viewport: { width: 834, height: 1112 } },
         'iPad Air (2020)': { os: 'ios', viewport: { width: 820, height: 1180 } },


### PR DESCRIPTION
## Summary
- Added `iPad (9th generation)` device configuration with viewport 810x1080
- Bumped package version to 4.1.59

## Test plan
- [ ] Verify iPad (9th generation) is available as a device option
- [ ] Run local build to confirm no build errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)