### PR TITLE
Fix undefined in githubURL when GITHUB_REPOSITORY is not set

### DIFF
--- a/src/lib/git.ts
+++ b/src/lib/git.ts
@@ -54,7 +54,7 @@ export default (ctx: Context): Git => {
 			commitId: gitInfo.commit_id.slice(0,6) || '',
 			commitMessage: gitInfo.commit_body || '',
 			commitAuthor: gitInfo.commit_author || '',
-			githubURL: githubURL ? githubURL : (ctx.env.GIT_URL) ? ctx.env.GIT_URL : `${constants.GITHUB_API_HOST}/repos/${process.env.GITHUB_REPOSITORY}/statuses/${gitInfo.commit_id}`,
+			githubURL: githubURL ? githubURL : (ctx.env.GIT_URL) ? ctx.env.GIT_URL : process.env.GITHUB_REPOSITORY ? `${constants.GITHUB_API_HOST}/repos/${process.env.GITHUB_REPOSITORY}/statuses/${gitInfo.commit_id}` : '',
 			baselineBranch: ctx.options.baselineBranch || ctx.env.BASELINE_BRANCH || ''
 		}
 	} else {
@@ -81,7 +81,7 @@ export default (ctx: Context): Git => {
 			commitId: res[0] || '',
 			commitMessage: res[2] || '',
 			commitAuthor: res[7] || '',
-			githubURL: githubURL ? githubURL : (ctx.env.GIT_URL) ? ctx.env.GIT_URL : `${constants.GITHUB_API_HOST}/repos/${process.env.GITHUB_REPOSITORY}/statuses/${res[1]}`,
+			githubURL: githubURL ? githubURL : (ctx.env.GIT_URL) ? ctx.env.GIT_URL : process.env.GITHUB_REPOSITORY ? `${constants.GITHUB_API_HOST}/repos/${process.env.GITHUB_REPOSITORY}/statuses/${res[1]}` : '',
 			baselineBranch: ctx.options.baselineBranch || ctx.env.BASELINE_BRANCH || ''
 		};
 	}


### PR DESCRIPTION
## Summary
- Added `iPad (9th generation)` device configuration with viewport 810x1080
- Fixed `githubURL` containing `undefined` when `GITHUB_REPOSITORY` env var is not set (falls back to empty string instead)
- Bumped package version to 4.1.59

## Test plan
- [ ] Verify githubURL no longer contains `undefined` when running outside GitHub Actions
- [ ] Verify githubURL is correctly set when running in GitHub Actions with `GITHUB_REPOSITORY` available
- [ ] Verify iPad (9th generation) is available as a device option

🤖 Generated with [Claude Code](https://claude.com/claude-code)