### PR TITLE
TE-7218: Add git info to PDF upload for Omni projects

### DIFF
--- a/src/commander/uploadPdf.ts
+++ b/src/commander/uploadPdf.ts
@@ -5,6 +5,7 @@ import { color, Listr, ListrDefaultRendererLogLevels, LoggerFormat } from 'listr
 import fs from 'fs';
 import auth from '../tasks/auth.js';
 import uploadPdfs from '../tasks/uploadPdfs.js';
+import getGitInfo from '../tasks/getGitInfo.js';
 import {startPdfPolling} from "../lib/utils.js";
 import constants from '../lib/constants.js';
 const command = new Command();
@@ -37,6 +38,7 @@ command
         let tasks = new Listr<Context>(
             [
                 auth(ctx),
+                getGitInfo(ctx),
                 uploadPdfs(ctx)
             ],
             {

--- a/src/lib/httpClient.ts
+++ b/src/lib/httpClient.ts
@@ -811,6 +811,11 @@ export default class httpClient {
             form.append('pdfNames', pdfNames);
         }
 
+        if (ctx.git?.branch) form.append('branch', ctx.git.branch);
+        if (ctx.git?.commitId) form.append('commitId', ctx.git.commitId);
+        if (ctx.git?.commitAuthor) form.append('commitAuthor', ctx.git.commitAuthor);
+        if (ctx.git?.commitMessage) form.append('commitMessage', ctx.git.commitMessage);
+
         try {
             const response = await this.axiosInstance.request({
                 url: ctx.env.SMARTUI_UPLOAD_URL + '/pdf/upload',


### PR DESCRIPTION
## Summary
- Adds git metadata (branch, commitId, commitAuthor, commitMessage) to the PDF upload pipeline
- `getGitInfo` task added to the upload-pdf Listr pipeline (`uploadPdf.ts`)
- Git fields appended to multipart form data in `httpClient.ts`
- Part of the 3-layer fix for TE-11089 (CLI → LSRS → DES)

## Context
Omni projects unify CLI exec, PDF upload, and web automation. PDF uploads were missing git traceability — this is Layer 1 of the fix.

## Test plan
- [x] `pnpm run build` clean
- [x] E2E verified on zsmartui-dev: baseline + comparison builds show branch=stage
- [x] E2E Groups 1-4 passing (PDF git info, screenshot counts, variants, regression)
- [ ] QA sign-off

JIRA: [TE-7218](https://lambdatest.atlassian.net/browse/TE-7218) / [TE-11089](https://lambdatest.atlassian.net/browse/TE-11089)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TE-7218]: https://lambdatest.atlassian.net/browse/TE-7218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TE-11089]: https://lambdatest.atlassian.net/browse/TE-11089?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ