### PR TITLE
TE-12436: fix screenshot upload ECONNRESET for payloads over 2MB

### DIFF
--- a/src/lib/httpClient.ts
+++ b/src/lib/httpClient.ts
@@ -330,6 +330,8 @@ export default class httpClient {
         browserName = browserName === constants.SAFARI ? constants.WEBKIT : browserName;
         const file = fs.readFileSync(ssPath);
         const form = new FormData();
+        // form-data defaults maxDataSize to 2MB; disable to allow large screenshots
+        (form as any).maxDataSize = Infinity;
         form.append('screenshot', file, { filename: `${ssName}.png`, contentType: 'image/png' });
         form.append('browser', browserName);
         form.append('viewport', viewport);
@@ -343,7 +345,9 @@ export default class httpClient {
             method: 'POST',
             headers: form.getHeaders(),
             data: form,
-            timeout: 30000
+            timeout: 30000,
+            maxBodyLength: Infinity, // prevent axios from limiting the body size
+            maxContentLength: Infinity, // prevent axios from limiting the content size
         })
             .then(() => {
                 log.debug(`${ssName} for ${browserName} ${viewport} uploaded successfully`);


### PR DESCRIPTION
## Summary

Fixes `ECONNRESET` / "socket hang up" on `/screenshot` uploads for any screenshot larger than ~2MB (full-page captures, high-DPI viewports, etc.).

JIRA: [TE-12436](https://lambdatest.atlassian.net/browse/TE-12436)

## Root Cause

`form-data` v4.x defaults `maxDataSize` to `2 * 1024 * 1024` (2 MB). `httpClient.uploadScreenshot` did not override it, and — unlike the other upload paths in the same file — also did not set axios `maxBodyLength` / `maxContentLength`.

When the combined stream detected the overflow mid-upload, `CombinedStream` aborted the stream, the server saw a truncated body, and the TCP connection was reset. The axios config in the failing HYE log confirms this:

```
"_valueLength": 2114763,
"dataSize": 0,
"maxDataSize": 2097152,      // form-data default (2 MB)
"maxContentLength": -1,       // axios default
"maxBodyLength": -1,          // axios default
"code": "ECONNRESET"
```

The screenshot in the failing log was 2,114,763 bytes — only ~17 KB over the 2 MB form-data limit.

## Fix

In `src/lib/httpClient.ts` `uploadScreenshot`:

1. Set `form.maxDataSize = Infinity` on the `FormData` instance so form-data does not abort large payloads.
2. Set `maxBodyLength: Infinity` and `maxContentLength: Infinity` on the axios request.

This matches what the other upload methods (log upload, S3 upload) in the same file already do.

## Test plan

- [ ] Upload a screenshot > 2 MB and confirm it succeeds (previously `ECONNRESET`).
- [ ] Upload a screenshot < 2 MB and confirm existing behavior is unchanged.
- [ ] Run an end-to-end SmartUI build with a full-page + retina capture workflow and confirm no retries are triggered by upload errors.
- [ ] Verify HYE webscanner job that previously failed now completes successfully.

## Related

Internal RFC: internal-docs `RFC-TE-12436-smartui-cli-screenshot-upload-2mb-limit.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TE-12436]: https://lambdatest.atlassian.net/browse/TE-12436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ