### PR TITLE
Add Node.js >= 20 engine constraint for Fastify v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lambdatest/smartui-cli",
-  "version": "4.1.63",
+  "version": "4.1.64",
   "description": "A command line interface (CLI) to run SmartUI tests on LambdaTest",
   "files": [
     "dist/**/*"
@@ -20,6 +20,9 @@
     "smartui",
     "cli"
   ],
+  "engines": {
+    "node": ">=20"
+  },
   "author": "LambdaTest <keys@lambdatest.com>",
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
## Summary
- Adds `"engines": { "node": ">=20" }` to `package.json` to enforce the Node.js minimum version required by Fastify v5
- Bumps version to `4.1.64`

## Root Cause
[PR #498](https://github.com/LambdaTest/smartui-cli/pull/498) upgraded Fastify from v4 to v5 to fix CVE-2026-25223. Fastify v5 uses `diagnostics_channel.tracingChannel()` — an API only available in Node.js >= 20. Users on older Node versions hit a `TypeError` crash at startup:

```
TypeError: diagnostics.tracingChannel is not a function
    at fastify/lib/wrap-thenable.js:10
```

Without an `engines` field, `npm install` gives no warning, and the error at runtime is cryptic and hard to diagnose.

## Fix
Adds an `engines` constraint so users get a clear error at install time instead of a runtime crash.

## Test plan
- [ ] Verify `npm install` warns on Node.js < 20
- [ ] Verify CLI starts successfully on Node.js >= 20
- [ ] Run e2e tests on Node.js 20+

🤖 Generated with [Claude Code](https://claude.com/claude-code)