### PR TITLE
Release 4.1.66

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lambdatest/smartui-cli",
-  "version": "4.1.65",
+  "version": "4.1.66",
   "description": "A command line interface (CLI) to run SmartUI tests on LambdaTest",
   "files": [
     "dist/**/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lambdatest/smartui-cli",
-  "version": "4.1.64",
+  "version": "4.1.65",
   "description": "A command line interface (CLI) to run SmartUI tests on LambdaTest",
   "files": [
     "dist/**/*"

--- a/src/lib/processSnapshot.ts
+++ b/src/lib/processSnapshot.ts
@@ -258,7 +258,7 @@ export async function prepareSnapshot(snapshot: Snapshot, ctx: Context): Promise
             dom: Buffer.from(snapshot.dom.html).toString('base64'),
             resources: cacheSerializedResources(snapshot.dom.resources),
             options: processedOptions,
-            cookies: Buffer.from(snapshot.dom.cookies).toString('base64'),
+            cookies:  Buffer.from(snapshot.dom.html ?? '').toString('base64'),
             renderViewports: renderViewports,
         },
         warnings: [...optionWarnings, ...snapshot.dom.warnings],

--- a/src/lib/processSnapshot.ts
+++ b/src/lib/processSnapshot.ts
@@ -258,7 +258,7 @@ export async function prepareSnapshot(snapshot: Snapshot, ctx: Context): Promise
             dom: Buffer.from(snapshot.dom.html).toString('base64'),
             resources: cacheSerializedResources(snapshot.dom.resources),
             options: processedOptions,
-            cookies:  Buffer.from(snapshot.dom.html ?? '').toString('base64'),
+            cookies:  Buffer.from(snapshot.dom.cookies ?? '').toString('base64'),
             renderViewports: renderViewports,
         },
         warnings: [...optionWarnings, ...snapshot.dom.warnings],


### PR DESCRIPTION
This pull request includes a minor version bump and a small fix to the snapshot preparation logic to improve robustness.

- Version update:
  * [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Bumped the package version from `4.1.65` to `4.1.66`.

- Bug fix / Robustness improvement:
  * [`src/lib/processSnapshot.ts`](diffhunk://#diff-f4a0a71049dc071dc081c306fc77a6494d9294d936aa10a1dee4dee8c1465b31L261-R261): Updated the `prepareSnapshot` function to handle cases where `snapshot.dom.cookies` may be `undefined` by defaulting to an empty string before encoding.