### PR TITLE
feat(TE-4324): propagate testName from session capabilities to snapshot options

### DIFF
--- a/src/lib/ctx.ts
+++ b/src/lib/ctx.ts
@@ -295,6 +295,7 @@ export default (options: Record<string, string>): Context => {
         isSnapshotCaptured: false,
         sessionCapabilitiesMap: new Map<string, any[]>(),
         sessionTestIdMap: new Map<string, string>(),
+        testIdTestNameMap: new Map<string, string>(),
         buildToSnapshotCountMap: new Map<string, number>(),
         sessionIdToSnapshotNameMap: new Map<string, string[]>(),
         fetchResultsForBuild: new Array<string>,

--- a/src/lib/processSnapshot.ts
+++ b/src/lib/processSnapshot.ts
@@ -89,6 +89,16 @@ export async function prepareSnapshot(snapshot: Snapshot, ctx: Context): Promise
                     processedOptions.testId = sessionCapabilities.id;
                 }
             }
+            if (options.testName) {
+                processedOptions.testName = options.testName;
+            } else if (processedOptions.testId && ctx.testIdTestNameMap?.has(processedOptions.testId)) {
+                processedOptions.testName = ctx.testIdTestNameMap.get(processedOptions.testId);
+            } else if (ctx.sessionCapabilitiesMap && ctx.sessionCapabilitiesMap.has(sessionId)) {
+                const sessionCapabilities = ctx.sessionCapabilitiesMap.get(sessionId);
+                if (sessionCapabilities && sessionCapabilities.name) {
+                    processedOptions.testName = sessionCapabilities.name;
+                }
+            }
         }
 
         if (options.web && Object.keys(options.web).length) {
@@ -576,6 +586,16 @@ export default async function processSnapshot(snapshot: Snapshot, ctx: Context):
                 const sessionCapabilities = ctx.sessionCapabilitiesMap.get(sessionId);
                 if (sessionCapabilities && sessionCapabilities.id) {
                     processedOptions.testId = sessionCapabilities.id;
+                }
+            }
+            if (options.testName) {
+                processedOptions.testName = options.testName;
+            } else if (processedOptions.testId && ctx.testIdTestNameMap?.has(processedOptions.testId)) {
+                processedOptions.testName = ctx.testIdTestNameMap.get(processedOptions.testId);
+            } else if (ctx.sessionCapabilitiesMap && ctx.sessionCapabilitiesMap.has(sessionId)) {
+                const sessionCapabilities = ctx.sessionCapabilitiesMap.get(sessionId);
+                if (sessionCapabilities && sessionCapabilities.name) {
+                    processedOptions.testName = sessionCapabilities.name;
                 }
             }
         }

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -96,18 +96,36 @@ export default async (ctx: Context): Promise<FastifyInstance<Server, IncomingMes
 			if (sessionId) {
 				if (ctx.sessionTestIdMap?.has(sessionId)) {
 					// Already have testId from LTMS fallback, skip getSmartUICapabilities
-					snapshot.options.testId = ctx.sessionTestIdMap.get(sessionId);
+					const cachedTestId = ctx.sessionTestIdMap.get(sessionId);
+					snapshot.options.testId = cachedTestId;
 					ctx.log.debug(`Using cached testId for sessionId ${sessionId}: ${snapshot.options.testId}`);
+					if (cachedTestId && ctx.testIdTestNameMap?.has(cachedTestId)) {
+						snapshot.options.testName = ctx.testIdTestNameMap.get(cachedTestId);
+						ctx.log.debug(`Using cached testName for testId ${cachedTestId}: ${snapshot.options.testName}`);
+					}
 				} else if (ctx.sessionCapabilitiesMap?.has(sessionId)) {
 					// Use cached capabilities if available
 					const cachedCapabilities = ctx.sessionCapabilitiesMap.get(sessionId);
 					capsBuildId = cachedCapabilities?.buildId || ''
+					if (cachedCapabilities?.name) {
+						snapshot.options.testName = cachedCapabilities.name;
+						if (cachedCapabilities?.id) {
+							ctx.testIdTestNameMap?.set(cachedCapabilities.id, cachedCapabilities.name);
+						}
+					}
 				} else {
 					// If not cached, fetch from API and cache it
 					try {
 						let fetchedCapabilitiesResp = await ctx.client.getSmartUICapabilities(sessionId, ctx.config, ctx.git, ctx.log, ctx.isStartExec, ctx.options.baselineBuild, ctx.env);
 						capsBuildId = fetchedCapabilitiesResp?.buildId || ''
 						ctx.log.debug(`fetch caps for sessionId: ${sessionId} are ${JSON.stringify(fetchedCapabilitiesResp)}`)
+						if (fetchedCapabilitiesResp?.name) {
+							snapshot.options.testName = fetchedCapabilitiesResp.name;
+							const testIdForCache = fetchedCapabilitiesResp?.id || fetchedCapabilitiesResp?.testId;
+							if (testIdForCache) {
+								ctx.testIdTestNameMap?.set(testIdForCache, fetchedCapabilitiesResp.name);
+							}
+						}
 						if (capsBuildId) {
 							ctx.sessionCapabilitiesMap.set(sessionId, fetchedCapabilitiesResp);
 						} else if (fetchedCapabilitiesResp && fetchedCapabilitiesResp?.sessionId) {
@@ -116,6 +134,9 @@ export default async (ctx: Context): Promise<FastifyInstance<Server, IncomingMes
 							// LTMS fallback: only testId returned, no buildId
 							ctx.sessionTestIdMap?.set(sessionId, fetchedCapabilitiesResp.testId);
 							snapshot.options.testId = fetchedCapabilitiesResp.testId;
+							if (fetchedCapabilitiesResp?.name) {
+								ctx.testIdTestNameMap?.set(fetchedCapabilitiesResp.testId, fetchedCapabilitiesResp.name);
+							}
 							ctx.log.debug(`Cached LTMS fallback testId for sessionId ${sessionId}: ${fetchedCapabilitiesResp.testId}`);
 						}
 					} catch (error: any) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -97,6 +97,7 @@ export interface Context {
     isSnapshotCaptured ?: boolean;
     sessionCapabilitiesMap?: Map<string, any[]>;
     sessionTestIdMap?: Map<string, string>;
+    testIdTestNameMap?: Map<string, string>;
     buildToSnapshotCountMap?: Map<string, number>;
     fetchResultsForBuild?: Array<string>;
     sessionIdToSnapshotNameMap?: Map<string, string[]>;
@@ -189,6 +190,7 @@ export interface Snapshot {
         ignoreType?: string[],
         sessionId?: string
         testId?: string
+        testName?: string
         sync?: boolean;
         contextId?: string;
         useExtendedViewport?: boolean;


### PR DESCRIPTION
## Summary
- Adds \`testIdTestNameMap\` (Map<testId, testName>) cache parallel to existing \`sessionTestIdMap\`, so that \`testName\` is restored on subsequent LTMS-fallback cache hits without re-calling LSRS.
- Populates \`snapshot.options.testName\` from the LSRS \`getSmartUICapabilities\` response across all 3 resolution paths: Redis-success, \`sessionCapabilitiesMap\` cache-hit, and LTMS-fallback.
- Adds optional \`testName\` to the \`Snapshot.options\` type.
- Part of a 3-repo change — \`testName\` rides on \`snapshot.options\` (same mechanism as \`testId\`/\`sessionId\` today), gets uploaded to S3 with the snapshot, and is later read by DOTUI for the outbound Kafka payload to DES.

## Related PRs
- LSRS: \`TE-4324\` on \`sushobhit-lt/smartui-rendering-service\`
- DOTUI: \`TE-4324\` on \`sushobhit-lt/dotlapse-visual-ui-pixel-private\`

## Test plan
- [ ] \`npm run build\` passes
- [ ] With a real Selenium/Playwright session, log \`snapshot.options.testName\` before S3 upload — confirm populated
- [ ] Exercise all 3 caps-resolution paths (Redis-success, cache-hit, LTMS-fallback) and verify testName is set in each
- [ ] Confirm \`testIdTestNameMap\` gets populated on first resolve and is used on subsequent snapshots with same sessionId
- [ ] Backward compat: snapshot without \`sessionId\` (pure CLI path) — \`testName\` stays empty, no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)