### PR TITLE
fix(TE-4324): read testName from caps with name fallback

### DIFF
--- a/src/lib/processSnapshot.ts
+++ b/src/lib/processSnapshot.ts
@@ -95,8 +95,9 @@ export async function prepareSnapshot(snapshot: Snapshot, ctx: Context): Promise
                 processedOptions.testName = ctx.testIdTestNameMap.get(processedOptions.testId);
             } else if (ctx.sessionCapabilitiesMap && ctx.sessionCapabilitiesMap.has(sessionId)) {
                 const sessionCapabilities = ctx.sessionCapabilitiesMap.get(sessionId);
-                if (sessionCapabilities && sessionCapabilities.name) {
-                    processedOptions.testName = sessionCapabilities.name;
+                const sessionTestName = sessionCapabilities?.testName || sessionCapabilities?.name;
+                if (sessionTestName) {
+                    processedOptions.testName = sessionTestName;
                 }
             }
         }
@@ -594,8 +595,9 @@ export default async function processSnapshot(snapshot: Snapshot, ctx: Context):
                 processedOptions.testName = ctx.testIdTestNameMap.get(processedOptions.testId);
             } else if (ctx.sessionCapabilitiesMap && ctx.sessionCapabilitiesMap.has(sessionId)) {
                 const sessionCapabilities = ctx.sessionCapabilitiesMap.get(sessionId);
-                if (sessionCapabilities && sessionCapabilities.name) {
-                    processedOptions.testName = sessionCapabilities.name;
+                const sessionTestName = sessionCapabilities?.testName || sessionCapabilities?.name;
+                if (sessionTestName) {
+                    processedOptions.testName = sessionTestName;
                 }
             }
         }

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -107,10 +107,11 @@ export default async (ctx: Context): Promise<FastifyInstance<Server, IncomingMes
 					// Use cached capabilities if available
 					const cachedCapabilities = ctx.sessionCapabilitiesMap.get(sessionId);
 					capsBuildId = cachedCapabilities?.buildId || ''
-					if (cachedCapabilities?.name) {
-						snapshot.options.testName = cachedCapabilities.name;
+					const cachedTestName = cachedCapabilities?.testName || cachedCapabilities?.name;
+					if (cachedTestName) {
+						snapshot.options.testName = cachedTestName;
 						if (cachedCapabilities?.id) {
-							ctx.testIdTestNameMap?.set(cachedCapabilities.id, cachedCapabilities.name);
+							ctx.testIdTestNameMap?.set(cachedCapabilities.id, cachedTestName);
 						}
 					}
 				} else {
@@ -119,11 +120,12 @@ export default async (ctx: Context): Promise<FastifyInstance<Server, IncomingMes
 						let fetchedCapabilitiesResp = await ctx.client.getSmartUICapabilities(sessionId, ctx.config, ctx.git, ctx.log, ctx.isStartExec, ctx.options.baselineBuild, ctx.env);
 						capsBuildId = fetchedCapabilitiesResp?.buildId || ''
 						ctx.log.debug(`fetch caps for sessionId: ${sessionId} are ${JSON.stringify(fetchedCapabilitiesResp)}`)
-						if (fetchedCapabilitiesResp?.name) {
-							snapshot.options.testName = fetchedCapabilitiesResp.name;
+						const fetchedTestName = fetchedCapabilitiesResp?.testName || fetchedCapabilitiesResp?.name;
+						if (fetchedTestName) {
+							snapshot.options.testName = fetchedTestName;
 							const testIdForCache = fetchedCapabilitiesResp?.id || fetchedCapabilitiesResp?.testId;
 							if (testIdForCache) {
-								ctx.testIdTestNameMap?.set(testIdForCache, fetchedCapabilitiesResp.name);
+								ctx.testIdTestNameMap?.set(testIdForCache, fetchedTestName);
 							}
 						}
 						if (capsBuildId) {
@@ -134,8 +136,8 @@ export default async (ctx: Context): Promise<FastifyInstance<Server, IncomingMes
 							// LTMS fallback: only testId returned, no buildId
 							ctx.sessionTestIdMap?.set(sessionId, fetchedCapabilitiesResp.testId);
 							snapshot.options.testId = fetchedCapabilitiesResp.testId;
-							if (fetchedCapabilitiesResp?.name) {
-								ctx.testIdTestNameMap?.set(fetchedCapabilitiesResp.testId, fetchedCapabilitiesResp.name);
+							if (fetchedTestName) {
+								ctx.testIdTestNameMap?.set(fetchedCapabilitiesResp.testId, fetchedTestName);
 							}
 							ctx.log.debug(`Cached LTMS fallback testId for sessionId ${sessionId}: ${fetchedCapabilitiesResp.testId}`);
 						}


### PR DESCRIPTION
## Summary

Follow-up to merged PR #511. The previous TE-4324 series read \`.name\` from the LSRS \`/sessions/capabilities\` response, but LSRS actually returns the test name under two different keys depending on the resolution path:

| LSRS path | Response key |
|---|---|
| Redis-success (\`SessionInfo\` JSON tag \`testName\`) | \`testName\` |
| LTMS-fallback (manual map \`{testId, name}\`) | \`name\` |

The earlier fix only worked for the LTMS-fallback path. The primary Redis-success path silently dropped the value, so \`snapshot.options.testName\` was never set and \`processedOptions.testName\` was empty downstream. Verified against a customer log showing \`fetch caps for sessionId: ... are {...,"testName":"dN6VuGgSQ6"}\` while \`Snapshot options:\` and \`Processed options:\` had no testName field.

## Change

Read \`testName\` first with \`name\` as fallback at all 5 caps-read sites:

- \`src/lib/server.ts\` — 3 caps-resolution branches (cache-hit, fresh-fetch primary, fresh-fetch LTMS-fallback)
- \`src/lib/processSnapshot.ts\` — 2 \`sessionCapabilitiesMap\` lookups in \`prepareSnapshot\` and \`processSnapshot\`

Resolution pattern: \`const testName = caps.testName || caps.name;\`

## Test plan

- [ ] \`npm run build\` passes (verified)
- [ ] With a real Selenium/Playwright session against LSRS Redis-success path, confirm \`Snapshot options:\` debug log includes \`testName\`
- [ ] Confirm \`Processed options:\` debug log also includes \`testName\` (was missing before)
- [ ] Confirm DOTUI \`lhps-dotlapse-add-screenshot\` Kafka payload carries \`testName\` end-to-end
- [ ] Backward compat: LTMS-fallback path (where response key is \`name\`) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)