### PR TITLE
Release: stage → prod (TE-4324: testName propagation + fallback fix)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lambdatest/smartui-cli",
-  "version": "4.1.66",
+  "version": "4.1.67",
   "description": "A command line interface (CLI) to run SmartUI tests on LambdaTest",
   "files": [
     "dist/**/*"

--- a/src/lib/ctx.ts
+++ b/src/lib/ctx.ts
@@ -295,6 +295,7 @@ export default (options: Record<string, string>): Context => {
         isSnapshotCaptured: false,
         sessionCapabilitiesMap: new Map<string, any[]>(),
         sessionTestIdMap: new Map<string, string>(),
+        testIdTestNameMap: new Map<string, string>(),
         buildToSnapshotCountMap: new Map<string, number>(),
         sessionIdToSnapshotNameMap: new Map<string, string[]>(),
         fetchResultsForBuild: new Array<string>,

--- a/src/lib/processSnapshot.ts
+++ b/src/lib/processSnapshot.ts
@@ -89,6 +89,16 @@ export async function prepareSnapshot(snapshot: Snapshot, ctx: Context): Promise
                     processedOptions.testId = sessionCapabilities.id;
                 }
             }
+            if (options.testName) {
+                processedOptions.testName = options.testName;
+            } else if (processedOptions.testId && ctx.testIdTestNameMap?.has(processedOptions.testId)) {
+                processedOptions.testName = ctx.testIdTestNameMap.get(processedOptions.testId);
+            } else if (ctx.sessionCapabilitiesMap && ctx.sessionCapabilitiesMap.has(sessionId)) {
+                const sessionCapabilities = ctx.sessionCapabilitiesMap.get(sessionId);
+                if (sessionCapabilities && sessionCapabilities.name) {
+                    processedOptions.testName = sessionCapabilities.name;
+                }
+            }
         }
 
         if (options.web && Object.keys(options.web).length) {
@@ -576,6 +586,16 @@ export default async function processSnapshot(snapshot: Snapshot, ctx: Context):
                 const sessionCapabilities = ctx.sessionCapabilitiesMap.get(sessionId);
                 if (sessionCapabilities && sessionCapabilities.id) {
                     processedOptions.testId = sessionCapabilities.id;
+                }
+            }
+            if (options.testName) {
+                processedOptions.testName = options.testName;
+            } else if (processedOptions.testId && ctx.testIdTestNameMap?.has(processedOptions.testId)) {
+                processedOptions.testName = ctx.testIdTestNameMap.get(processedOptions.testId);
+            } else if (ctx.sessionCapabilitiesMap && ctx.sessionCapabilitiesMap.has(sessionId)) {
+                const sessionCapabilities = ctx.sessionCapabilitiesMap.get(sessionId);
+                if (sessionCapabilities && sessionCapabilities.name) {
+                    processedOptions.testName = sessionCapabilities.name;
                 }
             }
         }

--- a/src/lib/processSnapshot.ts
+++ b/src/lib/processSnapshot.ts
@@ -95,8 +95,9 @@ export async function prepareSnapshot(snapshot: Snapshot, ctx: Context): Promise
                 processedOptions.testName = ctx.testIdTestNameMap.get(processedOptions.testId);
             } else if (ctx.sessionCapabilitiesMap && ctx.sessionCapabilitiesMap.has(sessionId)) {
                 const sessionCapabilities = ctx.sessionCapabilitiesMap.get(sessionId);
-                if (sessionCapabilities && sessionCapabilities.name) {
-                    processedOptions.testName = sessionCapabilities.name;
+                const sessionTestName = sessionCapabilities?.testName || sessionCapabilities?.name;
+                if (sessionTestName) {
+                    processedOptions.testName = sessionTestName;
                 }
             }
         }
@@ -594,8 +595,9 @@ export default async function processSnapshot(snapshot: Snapshot, ctx: Context):
                 processedOptions.testName = ctx.testIdTestNameMap.get(processedOptions.testId);
             } else if (ctx.sessionCapabilitiesMap && ctx.sessionCapabilitiesMap.has(sessionId)) {
                 const sessionCapabilities = ctx.sessionCapabilitiesMap.get(sessionId);
-                if (sessionCapabilities && sessionCapabilities.name) {
-                    processedOptions.testName = sessionCapabilities.name;
+                const sessionTestName = sessionCapabilities?.testName || sessionCapabilities?.name;
+                if (sessionTestName) {
+                    processedOptions.testName = sessionTestName;
                 }
             }
         }

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -96,18 +96,36 @@ export default async (ctx: Context): Promise<FastifyInstance<Server, IncomingMes
 			if (sessionId) {
 				if (ctx.sessionTestIdMap?.has(sessionId)) {
 					// Already have testId from LTMS fallback, skip getSmartUICapabilities
-					snapshot.options.testId = ctx.sessionTestIdMap.get(sessionId);
+					const cachedTestId = ctx.sessionTestIdMap.get(sessionId);
+					snapshot.options.testId = cachedTestId;
 					ctx.log.debug(`Using cached testId for sessionId ${sessionId}: ${snapshot.options.testId}`);
+					if (cachedTestId && ctx.testIdTestNameMap?.has(cachedTestId)) {
+						snapshot.options.testName = ctx.testIdTestNameMap.get(cachedTestId);
+						ctx.log.debug(`Using cached testName for testId ${cachedTestId}: ${snapshot.options.testName}`);
+					}
 				} else if (ctx.sessionCapabilitiesMap?.has(sessionId)) {
 					// Use cached capabilities if available
 					const cachedCapabilities = ctx.sessionCapabilitiesMap.get(sessionId);
 					capsBuildId = cachedCapabilities?.buildId || ''
+					if (cachedCapabilities?.name) {
+						snapshot.options.testName = cachedCapabilities.name;
+						if (cachedCapabilities?.id) {
+							ctx.testIdTestNameMap?.set(cachedCapabilities.id, cachedCapabilities.name);
+						}
+					}
 				} else {
 					// If not cached, fetch from API and cache it
 					try {
 						let fetchedCapabilitiesResp = await ctx.client.getSmartUICapabilities(sessionId, ctx.config, ctx.git, ctx.log, ctx.isStartExec, ctx.options.baselineBuild, ctx.env);
 						capsBuildId = fetchedCapabilitiesResp?.buildId || ''
 						ctx.log.debug(`fetch caps for sessionId: ${sessionId} are ${JSON.stringify(fetchedCapabilitiesResp)}`)
+						if (fetchedCapabilitiesResp?.name) {
+							snapshot.options.testName = fetchedCapabilitiesResp.name;
+							const testIdForCache = fetchedCapabilitiesResp?.id || fetchedCapabilitiesResp?.testId;
+							if (testIdForCache) {
+								ctx.testIdTestNameMap?.set(testIdForCache, fetchedCapabilitiesResp.name);
+							}
+						}
 						if (capsBuildId) {
 							ctx.sessionCapabilitiesMap.set(sessionId, fetchedCapabilitiesResp);
 						} else if (fetchedCapabilitiesResp && fetchedCapabilitiesResp?.sessionId) {
@@ -116,6 +134,9 @@ export default async (ctx: Context): Promise<FastifyInstance<Server, IncomingMes
 							// LTMS fallback: only testId returned, no buildId
 							ctx.sessionTestIdMap?.set(sessionId, fetchedCapabilitiesResp.testId);
 							snapshot.options.testId = fetchedCapabilitiesResp.testId;
+							if (fetchedCapabilitiesResp?.name) {
+								ctx.testIdTestNameMap?.set(fetchedCapabilitiesResp.testId, fetchedCapabilitiesResp.name);
+							}
 							ctx.log.debug(`Cached LTMS fallback testId for sessionId ${sessionId}: ${fetchedCapabilitiesResp.testId}`);
 						}
 					} catch (error: any) {

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -107,10 +107,11 @@ export default async (ctx: Context): Promise<FastifyInstance<Server, IncomingMes
 					// Use cached capabilities if available
 					const cachedCapabilities = ctx.sessionCapabilitiesMap.get(sessionId);
 					capsBuildId = cachedCapabilities?.buildId || ''
-					if (cachedCapabilities?.name) {
-						snapshot.options.testName = cachedCapabilities.name;
+					const cachedTestName = cachedCapabilities?.testName || cachedCapabilities?.name;
+					if (cachedTestName) {
+						snapshot.options.testName = cachedTestName;
 						if (cachedCapabilities?.id) {
-							ctx.testIdTestNameMap?.set(cachedCapabilities.id, cachedCapabilities.name);
+							ctx.testIdTestNameMap?.set(cachedCapabilities.id, cachedTestName);
 						}
 					}
 				} else {
@@ -119,11 +120,12 @@ export default async (ctx: Context): Promise<FastifyInstance<Server, IncomingMes
 						let fetchedCapabilitiesResp = await ctx.client.getSmartUICapabilities(sessionId, ctx.config, ctx.git, ctx.log, ctx.isStartExec, ctx.options.baselineBuild, ctx.env);
 						capsBuildId = fetchedCapabilitiesResp?.buildId || ''
 						ctx.log.debug(`fetch caps for sessionId: ${sessionId} are ${JSON.stringify(fetchedCapabilitiesResp)}`)
-						if (fetchedCapabilitiesResp?.name) {
-							snapshot.options.testName = fetchedCapabilitiesResp.name;
+						const fetchedTestName = fetchedCapabilitiesResp?.testName || fetchedCapabilitiesResp?.name;
+						if (fetchedTestName) {
+							snapshot.options.testName = fetchedTestName;
 							const testIdForCache = fetchedCapabilitiesResp?.id || fetchedCapabilitiesResp?.testId;
 							if (testIdForCache) {
-								ctx.testIdTestNameMap?.set(testIdForCache, fetchedCapabilitiesResp.name);
+								ctx.testIdTestNameMap?.set(testIdForCache, fetchedTestName);
 							}
 						}
 						if (capsBuildId) {
@@ -134,8 +136,8 @@ export default async (ctx: Context): Promise<FastifyInstance<Server, IncomingMes
 							// LTMS fallback: only testId returned, no buildId
 							ctx.sessionTestIdMap?.set(sessionId, fetchedCapabilitiesResp.testId);
 							snapshot.options.testId = fetchedCapabilitiesResp.testId;
-							if (fetchedCapabilitiesResp?.name) {
-								ctx.testIdTestNameMap?.set(fetchedCapabilitiesResp.testId, fetchedCapabilitiesResp.name);
+							if (fetchedTestName) {
+								ctx.testIdTestNameMap?.set(fetchedCapabilitiesResp.testId, fetchedTestName);
 							}
 							ctx.log.debug(`Cached LTMS fallback testId for sessionId ${sessionId}: ${fetchedCapabilitiesResp.testId}`);
 						}

--- a/src/types.ts
+++ b/src/types.ts
@@ -97,6 +97,7 @@ export interface Context {
     isSnapshotCaptured ?: boolean;
     sessionCapabilitiesMap?: Map<string, any[]>;
     sessionTestIdMap?: Map<string, string>;
+    testIdTestNameMap?: Map<string, string>;
     buildToSnapshotCountMap?: Map<string, number>;
     fetchResultsForBuild?: Array<string>;
     sessionIdToSnapshotNameMap?: Map<string, string[]>;
@@ -189,6 +190,7 @@ export interface Snapshot {
         ignoreType?: string[],
         sessionId?: string
         testId?: string
+        testName?: string
         sync?: boolean;
         contextId?: string;
         useExtendedViewport?: boolean;


### PR DESCRIPTION
## Summary
Promote stage to prod. Includes 5 commits since last release — full TE-4324 testName-propagation series.

## Commits being promoted
- \`d3fbd46\` Merge pull request #512 from sushobhit-lt/TE-4324-testname-fallback
- \`2b062b7\` fix(TE-4324): read testName from caps with name fallback
- \`c5c71af\` Merge pull request #511 from sushobhit-lt/TE-4324
- \`096a939\` fix(TE-4324): carry testName through processSnapshot/prepareSnapshot
- \`9ac57bf\` feat(TE-4324): propagate testName from session capabilities to snapshot options

## Highlights — TE-4324: testName end-to-end
- Populates \`snapshot.options.testName\` from LSRS \`/sessions/capabilities\` response in all 3 caps-resolution branches (Redis-success, sessionCapabilitiesMap cache-hit, LTMS-fallback).
- Adds \`testIdTestNameMap\` cache parallel to \`sessionTestIdMap\` so subsequent snapshots restore testName without re-calling the API.
- Carries \`testName\` through \`prepareSnapshot\` and \`processSnapshot\` allowlists into \`processedOptions\` so it survives to the S3 upload (was being silently stripped before this fix).
- Reads \`caps.testName ‖ caps.name\` to support both LSRS response shapes (Redis-success returns \`testName\`, LTMS-fallback returns \`name\`).

## Test plan
- [ ] With a real Selenium/Playwright session, run \`smartui exec\` and confirm \`Snapshot options:\` debug log includes \`testName\`.
- [ ] Confirm \`Processed options:\` debug log also includes \`testName\` (was missing pre-fix).
- [ ] End-to-end: confirm DOTUI publishes outbound \`lhps-dotlapse-add-screenshot\` Kafka payload with \`testName\` and DES persists it as \`screenshot.name\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)