### PR TITLE
chore: bump version to 4.1.67

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lambdatest/smartui-cli",
-  "version": "4.1.66",
+  "version": "4.1.67",
   "description": "A command line interface (CLI) to run SmartUI tests on LambdaTest",
   "files": [
     "dist/**/*"


### PR DESCRIPTION
## Summary
Bump CLI version from \`4.1.66\` to \`4.1.67\`.

Cuts a release that includes the full TE-4324 testName-propagation series merged via #511 and #512:

- \`feat(TE-4324): propagate testName from session capabilities to snapshot options\` (#511)
- \`fix(TE-4324): carry testName through processSnapshot/prepareSnapshot\` (#511)
- \`fix(TE-4324): read testName from caps with name fallback\` (#512)

## Test plan
- [ ] \`npm run build\` passes (verified locally)
- [ ] After release publish, verify \`smartui --version\` reports \`4.1.67\`
- [ ] Verify a real Selenium/Playwright snapshot run shows \`testName\` populated end-to-end (Snapshot options → Processed options → S3 → DOTUI → DES)

🤖 Generated with [Claude Code](https://claude.com/claude-code)