### PR TITLE
fix: scope basic auth to same-origin requests [TE-13690]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lambdatest/smartui-cli",
-  "version": "4.1.68",
+  "version": "4.1.70",
   "description": "A command line interface (CLI) to run SmartUI tests on LambdaTest",
   "files": [
     "dist/**/*"

--- a/src/lib/screenshot.ts
+++ b/src/lib/screenshot.ts
@@ -183,17 +183,12 @@ async function captureScreenshotsForConfig(
             });
         }
 
-        if (ctx.config.basicAuthorization) {
-            ctx.log.debug(`Adding basic authorization to the headers for root url`);
-            let token = Buffer.from(`${ctx.config.basicAuthorization.username}:${ctx.config.basicAuthorization.password}`).toString('base64');
-            headersObject['Authorization'] = `Basic ${token}`;
-        }
-
         ctx.log.debug(`Combined headers: ${JSON.stringify(headersObject)}`);
         if (Object.keys(headersObject).length > 0) {
             await page.setExtraHTTPHeaders(headersObject);
         }
 
+        const targetHostname = new URL(url).hostname;
 
         if (ctx.env.CAPTURE_RENDERING_ERRORS) {
             await page.route('**/*', async (route, request) => {
@@ -205,6 +200,12 @@ async function captureScreenshotsForConfig(
                         ...await request.allHeaders(),
                         ...constants.REQUEST_HEADERS
                     }
+                }
+
+                // Add basic authorization only for same-origin requests
+                if (ctx.config.basicAuthorization && requestHostname === targetHostname) {
+                    let token = Buffer.from(`${ctx.config.basicAuthorization.username}:${ctx.config.basicAuthorization.password}`).toString('base64');
+                    requestOptions.headers['Authorization'] = `Basic ${token}`;
                 }
 
                 try {
@@ -246,6 +247,17 @@ async function captureScreenshotsForConfig(
                 } catch (error: any) {
                     ctx.log.debug(`Handling request ${requestUrl}\n - aborted due to ${error.message}`);
                     route.abort();
+                }
+            });
+        } else if (ctx.config.basicAuthorization) {
+            // Intercept only when basic auth is configured, to scope it to same-origin requests
+            await page.route('**/*', async (route, request) => {
+                const requestHostname = new URL(request.url()).hostname;
+                if (requestHostname === targetHostname) {
+                    let token = Buffer.from(`${ctx.config.basicAuthorization.username}:${ctx.config.basicAuthorization.password}`).toString('base64');
+                    await route.continue({ headers: { ...await request.allHeaders(), 'Authorization': `Basic ${token}` } });
+                } else {
+                    await route.continue();
                 }
             });
         }


### PR DESCRIPTION
## RCA

**Root Cause:** In `src/lib/screenshot.ts`, basic auth credentials were applied globally to ALL requests via `page.setExtraHTTPHeaders()` (line 186-189, now removed). This Playwright API attaches the `Authorization` header to every HTTP request the page makes — including cross-origin requests to third-party APIs.

**Impact on this site:** The Angular SPA at `stg.universalstudioshollywood.com` calls `api-stg.universalparks.com/oidc/connect/token` to fetch a login token. The OIDC token endpoint expects client/app credentials in the Authorization header (per OAuth2 spec), but SmartUI was sending the user's basic auth credentials (`uprush:F73QqwDf`) instead → `400 Bad Request` → no token → SPA renders blank.

**Fix Applied (`screenshot.ts` only — capture flow):**

1. **Removed** basic auth from `page.setExtraHTTPHeaders()` (which was global/unscoped)
2. **Added route-based interception** that applies the `Authorization` header only to same-origin requests (where `requestHostname === targetHostname`):
   - **Non-error-capture path** (lines 193-204): New `page.route('**/*')` handler that adds the auth header only when the request hostname matches the target URL's hostname
   - **Error-capture path** (lines 218-222): Auth header added inside the existing route interceptor, scoped to same-origin via `requestHostname === targetHostname`

This ensures cross-origin requests (like the OIDC token call to `api-stg.universalparks.com`) are not polluted with the user's basic auth credentials.

## Test plan

- [ ] URL with basic auth + cross-origin OIDC calls → SPA renders, auth header only on target host
- [ ] URL with basic auth, no cross-origin calls → behavior unchanged
- [ ] URL without basic auth → no route interception, zero overhead

🤖 Generated with [Claude Code](https://claude.com/claude-code)