### PR TITLE
chore: switch npm publish to OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,10 @@ on:
   release:
      types: [published]
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
@@ -38,12 +42,12 @@ jobs:
 
     - name: Release beta package
       if: steps.check-beta.outputs.IS_BETA == 'true'
-      run: pnpm run release:beta
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      run: |
+        pnpm run build
+        pnpm publish --tag beta --access public --provenance --no-git-checks
 
     - name: Release stable package
       if: steps.check-beta.outputs.IS_BETA == 'false'
-      run: pnpm run release
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      run: |
+        pnpm run build
+        pnpm publish --access public --provenance --no-git-checks


### PR DESCRIPTION
## Summary
- Replace long-lived `NPM_TOKEN` with GitHub Actions OIDC ("trusted publishing"). Adds `id-token: write` permission and `--provenance` flag on `pnpm publish`; removes `NODE_AUTH_TOKEN` env block.
- Side benefit: published packages will show the ✅ "Published from GitHub Actions" provenance badge on npmjs.com.

## Why
npm shortened classic-token lifetimes drastically in late 2025 (max 90 days for granular tokens with write scope, default 7 days; classic tokens revoked Dec 9 2025). OIDC eliminates the rotation toil entirely — short-lived publish tokens are minted per run, scoped to this repo + workflow, can't be reused from anywhere else.

References:
- [npm: Trusted publishers](https://docs.npmjs.com/trusted-publishers/)
- [npm: Generating provenance statements](https://docs.npmjs.com/generating-provenance-statements/)
- [GitHub: OIDC in Actions](https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/about-security-hardening-with-openid-connect)

## ⚠️ Prerequisite — npmjs.com side (manual, one-time)
Before merging, someone with admin on `@lambdatest/smartui-cli` must configure the trusted publisher on npmjs.com, **or the next release will fail**:

1. npmjs.com → \`@lambdatest/smartui-cli\` → Settings → **Publishing access** → **Add trusted publisher** → GitHub Actions
2. Fill in:
   - Organization: \`LambdaTest\`
   - Repository: \`smartui-cli\`
   - Workflow filename: \`release.yaml\`
   - Environment: *(leave blank)*

## Test plan
- [ ] npmjs.com trusted publisher configured (see above)
- [ ] Cut a \`-beta\` GitHub release first (e.g. \`v4.1.72-beta.1\`) and verify the workflow publishes successfully
- [ ] Confirm the published beta shows the "Published from GitHub Actions" provenance badge on npmjs.com
- [ ] Cut a stable release and re-verify
- [ ] After confirmed working: delete \`NPM_TOKEN\` from repo secrets and revoke the underlying token on npmjs.com

## Out of scope (recommended follow-ups)
- Bump \`actions/checkout@v3\` → \`v4\` (v3 is EOL)
- Bump Node 18 → 20 (Node 18 went EOL April 2025)
- Pin pnpm version via \`pnpm/action-setup@v4\` instead of floating \`npm install -g pnpm\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)